### PR TITLE
Add API support for possible future derivation scheme

### DIFF
--- a/src/Cardano/Crypto/Wallet.hs
+++ b/src/Cardano/Crypto/Wallet.hs
@@ -20,10 +20,13 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE PatternSynonyms     #-}
 
 module Cardano.Crypto.Wallet
     ( ChainCode(..)
+    , DerivationScheme(..)
+    , pattern LatestScheme
     -- * Extended Private & Public types
     , XPrv
     , XPub(..)
@@ -153,15 +156,15 @@ xPrvChangePass oldPass newPass (XPrv ekey) =
     XPrv $ encryptedChangePass oldPass newPass ekey
 
 -- | Derive a child extended private key from an extended private key
-deriveXPrv :: ByteArrayAccess passPhrase => passPhrase -> XPrv -> Word32 -> XPrv
-deriveXPrv passPhrase (XPrv ekey) n =
-    XPrv (encryptedDerivePrivate ekey passPhrase n)
+deriveXPrv :: ByteArrayAccess passPhrase => DerivationScheme -> passPhrase -> XPrv -> Word32 -> XPrv
+deriveXPrv ds passPhrase (XPrv ekey) n =
+    XPrv (encryptedDerivePrivate ds ekey passPhrase n)
 
 -- | Derive a child extended private key from an extended private key
-deriveXPub :: XPub -> Word32 -> Maybe XPub
-deriveXPub (XPub pub (ChainCode cc)) n
+deriveXPub :: DerivationScheme -> XPub -> Word32 -> Maybe XPub
+deriveXPub ds (XPub pub (ChainCode cc)) n
     | n >= 0x8000000 = Nothing
-    | otherwise      = Just $ uncurry XPub $ second ChainCode $ encryptedDerivePublic (pub,cc) n
+    | otherwise      = Just $ uncurry XPub $ second ChainCode $ encryptedDerivePublic ds (pub,cc) n
 
 sign :: (ByteArrayAccess passPhrase, ByteArrayAccess msg)
      => passPhrase

--- a/src/Cardano/Crypto/Wallet/Types.hs
+++ b/src/Cardano/Crypto/Wallet/Types.hs
@@ -1,11 +1,20 @@
+{-# LANGUAGE PatternSynonyms #-}
 module Cardano.Crypto.Wallet.Types
     ( ChainCode(..)
+    , DerivationScheme(..)
+    , pattern LatestScheme
     ) where
 
 import           Control.DeepSeq (NFData)
 import           Data.ByteArray  (ByteArrayAccess)
 import           Data.ByteString (ByteString)
 import           Data.Hashable   (Hashable)
+
+data DerivationScheme = DerivationScheme1
+    deriving (Show, Eq, Ord, Enum, Bounded)
+
+pattern LatestScheme :: DerivationScheme
+pattern LatestScheme = DerivationScheme1
 
 newtype ChainCode = ChainCode ByteString
     deriving (Show, Eq, Ord, ByteArrayAccess, NFData, Hashable)


### PR DESCRIPTION
The current derivation scheme is the only one currently defined,
but in the future, algorithm additions can be made whilst keeping
compatibility with existing scheme(s).