### PR TITLE
Remove cardano-crypto's dep on inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .stack-work
 dist
 .dir-locals.el
+
+tests/**/*.md

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -37,7 +37,6 @@ library
                        Crypto.Encoding.BIP39.English
   build-depends:       base >= 4.7 && < 5
                      , memory
-                     , inspector
                      , deepseq
                      , bytestring
                      , basement
@@ -92,6 +91,7 @@ test-suite cardano-crypto-golden-tests
 executable golden-tests
   hs-source-dirs:      test
   main-is:             GoldenTest.hs
+  other-modules:       Test.Orphans
   build-depends:       base
                      , basement
                      , foundation

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -77,6 +77,7 @@ test-suite cardano-crypto-golden-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             GoldenTest.hs
+  other-modules:       Test.Orphans
   build-depends:       base
                      , basement
                      , foundation

--- a/src/Cardano/Crypto/Encoding/Seed.hs
+++ b/src/Cardano/Crypto/Encoding/Seed.hs
@@ -47,9 +47,6 @@ module Cardano.Crypto.Encoding.Seed
     , MnemonicWords
     ) where
 
-import Inspector.Display
-import Inspector.Parser
-
 import Foundation
 import Foundation.Check
 import Basement.Nat
@@ -84,16 +81,6 @@ instance Arbitrary ScrambleIV where
     arbitrary = do
         l <- arbitrary :: Gen (ListN 4 Word8)
         pure $ throwCryptoError $ mkScrambleIV $ B.pack $ ListN.unListN l
-instance Display ScrambleIV where
-    display = displayByteArrayAccess
-    encoding _ = "hexadecimal"
-    comment _ = Just "valid value are only 4 bytes long (8 hexadecimal characters)"
-instance HasParser ScrambleIV where
-    getParser = do
-        bs <- strParser >>= parseByteArray
-        case mkScrambleIV bs of
-            CryptoFailed err -> reportError (Expected "ScrambleIV" (show err))
-            CryptoPassed r   -> pure r
 
 mkScrambleIV :: ByteString -> CryptoFailable ScrambleIV
 mkScrambleIV bs

--- a/src/Cardano/Crypto/Praos/VRF.hs
+++ b/src/Cardano/Crypto/Praos/VRF.hs
@@ -20,7 +20,7 @@ module Cardano.Crypto.Praos.VRF
     , publicKeyFromBytes
 
     , -- * Proof
-      Proof
+      Proof(..)
     , generate
     , verify
 
@@ -31,7 +31,6 @@ module Cardano.Crypto.Praos.VRF
 import Foundation
 import Basement.NormalForm
 import Foundation.Check (Arbitrary(..))
-import Foundation.Parser (elements)
 
 import Data.ByteArray (ByteArrayAccess, ByteArray, Bytes)
 
@@ -45,9 +44,6 @@ import qualified Crypto.Hash as Hash
 import           Crypto.MAC.HMAC (HMAC)
 import qualified Crypto.MAC.HMAC as HMAC
 
-import qualified Inspector.Parser as I
-import qualified Inspector.Display as I
-
 data KeyPair = KeyPair
     { toPublicKey :: !PublicKey
     , toSecretKey :: !SecretKey
@@ -60,25 +56,9 @@ instance NormalForm KeyPair where
 
 newtype SecretKey = SecretKey { toScalar :: Scalar }
   deriving (Eq, Show, Typeable, NormalForm, Arbitrary)
-instance I.HasParser SecretKey where
-    getParser = c <$> I.getParser
-      where
-        c :: Bytes -> SecretKey
-        c = secretKeyFromBytes
-instance I.Display SecretKey where
-    encoding _ = "hex"
-    display = I.display . (secretKeyToBytes :: SecretKey -> Bytes)
 
 newtype PublicKey = PublicKey { toPoint :: Point }
   deriving (Eq, Show, Typeable, NormalForm, Arbitrary)
-instance I.HasParser PublicKey where
-    getParser = c <$> I.getParser
-      where
-        c :: Bytes -> PublicKey
-        c = either (error . fromList) id . publicKeyFromBytes
-instance I.Display PublicKey where
-    display = I.display . (publicKeyToBytes :: PublicKey -> Bytes)
-    encoding _ = "hex"
 
 -- | generate a new secret key
 generateKey :: MonadRandom randomly => randomly SecretKey
@@ -128,15 +108,6 @@ hash message key = HMAC.hmac message k
 
 data Proof = Proof PublicKey DLEQ.Proof
   deriving (Eq, Show, Typeable)
-instance I.HasParser Proof where
-    getParser = do
-        elements "u: "
-        u <- I.getParser
-        elements ", "
-        Proof u <$> I.getParser
-instance I.Display Proof where
-    encoding _ = "u: `Public Key`, " <> I.encoding (Proxy :: Proxy DLEQ.Proof)
-    display (Proof u dleq) = "u: " <> I.display u <> ", " <> I.display dleq
 
 -- | Generate a Deterministicaly _random_ 'Output' and an associated 'Proof'
 --

--- a/src/Cardano/Crypto/Wallet.hs
+++ b/src/Cardano/Crypto/Wallet.hs
@@ -49,8 +49,6 @@ module Cardano.Crypto.Wallet
     , verify
     ) where
 
-import qualified Foundation as F
-
 import           Control.DeepSeq                 (NFData)
 import           Control.Arrow                   (second)
 import           Crypto.Error                    (throwCryptoError, CryptoFailable(..), CryptoError(..))
@@ -69,21 +67,10 @@ import           Cardano.Crypto.Wallet.Pure      ({-XPub (..),-} hFinalize,
                                                   hInitSeed)
 import           Cardano.Crypto.Wallet.Types
 
-import           Inspector.Display
-import           Inspector.Parser
-
 import           GHC.Stack
 
 newtype XPrv = XPrv EncryptedKey
     deriving (NFData, ByteArrayAccess)
-instance Display XPrv where
-    display = displayByteArrayAccess
-    encoding _ = "hexadecimal"
-    comment _ = Just "encrypted extended private key"
-instance HasParser XPrv where
-    getParser = strParser >>= parseByteArray >>= \s -> case xprv (s :: ByteString) of
-        Left err -> reportError $ Expected "xPrv" (F.fromList err)
-        Right e  -> pure e
 
 data XPub = XPub
     { xpubPublicKey :: !ByteString
@@ -91,26 +78,10 @@ data XPub = XPub
     } deriving (Generic)
 
 instance NFData XPub
-instance Display XPub where
-    display = displayByteArrayAccess . unXPub
-    encoding _ = "hexadecimal"
-    comment _ = Just "extended public key"
-instance HasParser XPub where
-    getParser = strParser >>= parseByteArray >>= \s -> case xpub (s :: ByteString) of
-        Left err -> reportError $ Expected "xPub" (F.fromList err)
-        Right e  -> pure e
 
 newtype XSignature = XSignature
     { unXSignature :: ByteString
-    } deriving (Show, Eq, Ord, NFData, Hashable)
-instance Display XSignature where
-    display (XSignature bs) = displayByteArrayAccess bs
-    encoding _ = "hexadecimal"
-    comment _ = Just "extended signature"
-instance HasParser XSignature where
-    getParser = strParser >>= parseByteArray >>= \s -> case xsignature s of
-        Left err -> reportError $ Expected "XSignature" (F.fromList err)
-        Right e  -> pure e
+    } deriving (Show, Eq, Ord, NFData, Hashable, ByteArrayAccess)
 
 -- | Generate a new XPrv
 --

--- a/src/Cardano/Crypto/Wallet/Types.hs
+++ b/src/Cardano/Crypto/Wallet/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Cardano.Crypto.Wallet.Types
     ( ChainCode(..)
     , DerivationScheme(..)
@@ -14,25 +13,11 @@ import           Data.Hashable   (Hashable)
 import Foundation
 import Foundation.Collection (nonEmpty_)
 import Foundation.Check (Arbitrary(..), frequency)
-import Inspector.Display
-import Inspector.Parser
 
 data DerivationScheme = DerivationScheme1 | DerivationScheme2
     deriving (Show, Eq, Ord, Enum, Bounded, Typeable)
 instance Arbitrary DerivationScheme where
     arbitrary = frequency $ nonEmpty_ [ (1, pure DerivationScheme1), (1, pure DerivationScheme2) ]
-instance Display DerivationScheme where
-    encoding _ = "string \"derivation-scheme1\""
-    display DerivationScheme1 = "\"derivation-scheme1\""
-    display DerivationScheme2 = "\"derivation-scheme2\""
-    comment _ = Just "valid values are: \"derivation-scheme1\" or \"derivation-scheme2\""
-instance HasParser DerivationScheme where
-    getParser = do
-        str <- strParser
-        case str of
-            "derivation-scheme1" -> pure DerivationScheme1
-            "derivation-scheme2" -> pure DerivationScheme2
-            s                    -> reportError (Expected "derivation-scheme1 or derivation-scheme2" s)
 
 pattern LatestScheme :: DerivationScheme
 pattern LatestScheme = DerivationScheme2

--- a/src/Crypto/DLEQ.hs
+++ b/src/Crypto/DLEQ.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 module Crypto.DLEQ
     ( DLEQ(..)
     , Proof(..)
     , ParallelProof(..)
     , ParallelProofs(..)
-    , Challenge
+    , Challenge(..)
     , generate
     , verify
     , generateParallel
@@ -15,16 +13,13 @@ module Crypto.DLEQ
 
 import           Foundation
 import           Basement.Compat.Semigroup (Semigroup)
-import           Foundation.Parser (elements)
+
 import           Crypto.ECC.P256
 import           Data.ByteArray (Bytes,ByteArrayAccess,ByteArray)
 
 
 import Data.List (zipWith)
 import Data.Foldable (concatMap)
-
-import qualified Inspector.Parser as I
-import qualified Inspector.Display as I
 
 data DLEQ = DLEQ
     { dleq_g1 :: !Point -- ^ g1 parameter
@@ -35,26 +30,12 @@ data DLEQ = DLEQ
 
 newtype Challenge = Challenge Bytes
     deriving (Show,Eq,Ord,Typeable,Semigroup,Monoid,ByteArrayAccess,ByteArray)
-instance I.HasParser Challenge where
-    getParser = Challenge <$> I.getParser
-instance I.Display Challenge where
-    encoding _ = "hex"
-    display (Challenge c) = I.display c
 
 -- | The generated proof
 data Proof = Proof
     { proofC :: !Challenge
     , proofZ :: !Scalar
     } deriving (Show,Eq,Typeable)
-instance I.HasParser Proof where
-    getParser = do
-        elements "challenge: "
-        c <- I.getParser
-        elements ", z: "
-        Proof c <$> I.getParser
-instance I.Display Proof where
-    encoding _ = "challenge: " <> I.encoding (Proxy @Challenge) <> ", z: " <> I.encoding (Proxy @Scalar)
-    display (Proof c z) = "challenge: " <> I.display c <> ", z: " <> I.display z
 
 newtype ParallelProof = ParallelProof { parallelProofZ :: Scalar }
     deriving (Show,Eq,Typeable)

--- a/src/Crypto/ECC/P256.hs
+++ b/src/Crypto/ECC/P256.hs
@@ -54,9 +54,6 @@ import           Crypto.Number.Serialize
 import           Crypto.Number.ModArithmetic (expFast)
 import           Crypto.Random
 
-import qualified Inspector.Parser as I
-import qualified Inspector.Display as I
-
 #ifdef OPENSSL
 import qualified Crypto.OpenSSL.ECC as SSL
 import GHC.Integer.GMP.Internals (recipModInteger)
@@ -125,11 +122,6 @@ instance Arbitrary Scalar where
     arbitrary = do
         drg <- drgNewTest <$> arbitrary
         pure $ fst $ withDRG drg keyGenerate
-instance I.HasParser Scalar where
-    getParser = Scalar <$> I.getParser
-instance I.Display Scalar where
-    encoding _ = I.encoding (Proxy @Integer)
-    display = I.display . unScalar
 
 scalarToBytes :: ByteArray b => Scalar -> b
 scalarToBytes = i2ospOf_ 32 . unScalar

--- a/src/Crypto/Encoding/BIP39.hs
+++ b/src/Crypto/Encoding/BIP39.hs
@@ -44,8 +44,6 @@ import           Basement.NormalForm
 import           Basement.Compat.Typeable
 
 import           Foundation.Check
-import           Inspector.Display
-import           Inspector.Parser
 
 import           Control.Monad (replicateM)
 import           Data.Bits
@@ -144,15 +142,6 @@ instance Arbitrary (Entropy 224) where
     arbitrary = fromMaybe (error "arbitrary (Entropy 224)") . toEntropy . BS.pack <$> replicateM 28 arbitrary
 instance Arbitrary (Entropy 256) where
     arbitrary = fromMaybe (error "arbitrary (Entropy 256)") . toEntropy . BS.pack <$> replicateM 32 arbitrary
-instance Display (Entropy n) where
-    display (Entropy r _) = displayByteArrayAccess r
-    encoding _ = "hexadecimal"
-instance (KnownNat n, KnownNat csz, NatWithinBound Int n, ValidEntropySize n, CheckSumBits n ~ csz) => HasParser (Entropy n) where
-    getParser = do
-        bs <- strParser >>= parseByteArray
-        case toEntropy bs of
-            Nothing -> reportError (Expected "Entropy" "not the correct size")
-            Just r  -> pure r
 
 -- | Get the raw binary associated with the entropy
 entropyRaw :: Entropy n -> ByteString

--- a/test/GoldenTest.hs
+++ b/test/GoldenTest.hs
@@ -35,6 +35,8 @@ import           Crypto.Encoding.BIP39
 import qualified Crypto.Encoding.BIP39.English as English
 import qualified Cardano.Crypto.Praos.VRF as VRF
 
+import Test.Orphans
+
 main :: IO ()
 main = defaultMain $ do
     goldenPaperwallet

--- a/test/Test/Orphans.hs
+++ b/test/Test/Orphans.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Orphans
+    (
+    ) where
+
+import Foundation
+import Foundation.Parser (elements)
+import Basement.Nat
+
+import Inspector.Display
+import Inspector.Parser
+
+import Crypto.Error
+
+import Data.ByteArray (Bytes)
+
+import qualified Cardano.Crypto.Encoding.Seed as Seed
+import qualified Crypto.ECC.P256 as P256
+import qualified Cardano.Crypto.Wallet.Types as Wallet
+import qualified Cardano.Crypto.Wallet       as Wallet
+import qualified Crypto.DLEQ as DLEQ
+import qualified Cardano.Crypto.Praos.VRF as VRF
+import qualified Crypto.Encoding.BIP39 as BIP39
+
+instance Display Seed.ScrambleIV where
+    display = displayByteArrayAccess
+    encoding _ = "hexadecimal"
+    comment _ = Just "valid value are only 4 bytes long (8 hexadecimal characters)"
+instance HasParser Seed.ScrambleIV where
+    getParser = do
+        bs <- strParser >>= parseByteArray
+        case Seed.mkScrambleIV bs of
+            CryptoFailed err -> reportError (Expected "ScrambleIV" (show err))
+            CryptoPassed r   -> pure r
+
+instance HasParser P256.Scalar where
+    getParser = P256.Scalar <$> getParser
+instance Display P256.Scalar where
+    encoding _ = encoding (Proxy @Integer)
+    display = display . P256.unScalar
+
+instance Display Wallet.DerivationScheme where
+    encoding _ = "string \"derivation-scheme1\""
+    display Wallet.DerivationScheme1 = "\"derivation-scheme1\""
+    display Wallet.DerivationScheme2 = "\"derivation-scheme2\""
+    comment _ = Just "valid values are: \"derivation-scheme1\" or \"derivation-scheme2\""
+instance HasParser Wallet.DerivationScheme where
+    getParser = do
+        str <- strParser
+        case str of
+            "derivation-scheme1" -> pure Wallet.DerivationScheme1
+            "derivation-scheme2" -> pure Wallet.DerivationScheme2
+            s                    -> reportError (Expected "derivation-scheme1 or derivation-scheme2" s)
+
+instance Display Wallet.XPub where
+    display = displayByteArrayAccess . Wallet.unXPub
+    encoding _ = "hexadecimal"
+    comment _ = Just "extended public key"
+instance HasParser Wallet.XPub where
+    getParser = strParser >>= parseByteArray >>= \s -> case Wallet.xpub s of
+        Left err -> reportError $ Expected "xPub" (fromList err)
+        Right e  -> pure e
+
+instance Display Wallet.XPrv where
+    display = displayByteArrayAccess
+    encoding _ = "hexadecimal"
+    comment _ = Just "encrypted extended private key"
+instance HasParser Wallet.XPrv where
+    getParser = strParser >>= parseByteArray >>= \s -> case Wallet.xprv (s :: Bytes) of
+        Left err -> reportError $ Expected "xPrv" (fromList err)
+        Right e  -> pure e
+
+instance Display Wallet.XSignature where
+    display = displayByteArrayAccess
+    encoding _ = "hexadecimal"
+    comment _ = Just "extended signature"
+instance HasParser Wallet.XSignature where
+    getParser = strParser >>= parseByteArray >>= \s -> case Wallet.xsignature s of
+        Left err -> reportError $ Expected "XSignature" (fromList err)
+        Right e  -> pure e
+
+instance HasParser DLEQ.Challenge where
+    getParser = DLEQ.Challenge <$> getParser
+instance Display DLEQ.Challenge where
+    encoding _ = "hex"
+    display (DLEQ.Challenge c) = display c
+
+instance HasParser DLEQ.Proof where
+    getParser = do
+        elements "challenge: "
+        c <- getParser
+        elements ", z: "
+        DLEQ.Proof c <$> getParser
+instance Display DLEQ.Proof where
+    encoding _ = "challenge: " <> encoding (Proxy @DLEQ.Challenge) <> ", z: " <> encoding (Proxy @P256.Scalar)
+    display (DLEQ.Proof c z) = "challenge: " <> display c <> ", z: " <> display z
+
+instance HasParser VRF.SecretKey where
+    getParser = c <$> getParser
+      where
+        c :: Bytes -> VRF.SecretKey
+        c = VRF.secretKeyFromBytes
+instance Display VRF.SecretKey where
+    encoding _ = "hex"
+    display = display . (VRF.secretKeyToBytes :: VRF.SecretKey -> Bytes)
+
+instance HasParser VRF.PublicKey where
+    getParser = c <$> getParser
+      where
+        c :: Bytes -> VRF.PublicKey
+        c = either (error . fromList) id . VRF.publicKeyFromBytes
+instance Display VRF.PublicKey where
+    display = display . (VRF.publicKeyToBytes :: VRF.PublicKey -> Bytes)
+    encoding _ = "hex"
+
+instance HasParser VRF.Proof where
+    getParser = do
+        elements "u: "
+        u <- getParser
+        elements ", "
+        VRF.Proof u <$> getParser
+instance Display VRF.Proof where
+    encoding _ = "u: `Public Key`, " <> encoding (Proxy :: Proxy DLEQ.Proof)
+    display (VRF.Proof u dleq) = "u: " <> display u <> ", " <> display dleq
+
+instance Display (BIP39.Entropy n) where
+    display = displayByteArrayAccess . BIP39.entropyRaw
+    encoding _ = "hexadecimal"
+instance (KnownNat n, KnownNat csz, NatWithinBound Int n, BIP39.ValidEntropySize n, BIP39.CheckSumBits n ~ csz) => HasParser (BIP39.Entropy n) where
+    getParser = do
+        bs <- strParser >>= parseByteArray
+        case BIP39.toEntropy bs of
+            Nothing -> reportError (Expected "Entropy" "not the correct size")
+            Just r  -> pure r


### PR DESCRIPTION
this PR moves all the instances to `inspector` types to a separate module, only used for tests with all orphan instances.