### PR TITLE
update inspector to generate rust output too

### DIFF
--- a/.haskell-ci
+++ b/.haskell-ci
@@ -7,16 +7,15 @@ compiler: ghc-8.4 ghc-8.4-rc1
 option: exe flag=cardano-crypto:golden-tests
 
 # builds
-build: ghc-8.0 gitdep=inspector
-build: ghc-8.2 gitdep=inspector
-build: ghc-8.2-exe gitdep=inspector exe
+build: ghc-8.0 gitdep=inspector extradep=basement-0.0.7 extradep=foundation-0.0.20 extradep=memory-0.14.15
+build: ghc-8.2 gitdep=inspector extradep=basement-0.0.7 extradep=foundation-0.0.20 extradep=memory-0.14.15
 build: ghc-8.4 gitdep=inspector extradep=basement-0.0.7 extradep=cryptonite-0.25 extradep=cryptonite-openssl-0.6 extradep=foundation-0.0.20 extradep=hashable-1.2.6.1 extradep=memory-0.14.15 allow-newer
 
 # packages
 package: '.'
 
 # deps:
-gitdep: inspector https://github.com/primetype/inspector 674c5d3a4733088f14164b0924824b7433e06428
+gitdep: inspector https://github.com/primetype/inspector b2e49ba7df07187f6bf9feeb505ef325d3bd00ac
 
 # extra builds
 hlint: allowed-failure


### PR DESCRIPTION
example of rust output:

```rust
/// # GoldenTests: cardano/crypto/scramble128
///
/// 
///
/// ## Input(s)
///
/// ```
/// iv ([u8;4]) = "hexadecimal encoded bytes"
/// input ([u8;16]) = "UTF8 BIP39 passphrase (english)"
/// passphrase (&'static str) = "Bouble quoted, encoded string."
/// ```
///
/// ## Output(s)
///
/// ```
/// shielded_input ([u8;20]) = "UTF8 BIP39 passphrase (english)"
/// ```
struct TestVector {
  iv : [u8;4],
  input : [u8;16],
  passphrase : &'static str,
  shielded_input : [u8;20]
}

const GoldenTests : [TestVector;3] =
  [ TestVector
    { iv : [0x00, 0x00, 0x00, 0x00]
    , input : [0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f]
    , passphrase : ""
    , shielded_input : [0x00, 0x00, 0x00, 0x00, 0x7d, 0xa9, 0x48, 0x4e, 0xbd, 0xbd, 0xf5, 0x78, 0x38, 0xe2, 0x34, 0x9c, 0x58, 0xdd, 0x2f, 0xa4]
    }
  , TestVector
    { iv : [0x00, 0x01, 0x02, 0x03]
    , input : [0x5a, 0x94, 0x0d, 0x50, 0xab, 0x0d, 0x4e, 0x2e, 0xbf, 0x3b, 0x2c, 0x6e, 0xb3, 0x99, 0xe8, 0x27]
    , passphrase : "Cardano Ada"
    , shielded_input : [0x00, 0x01, 0x02, 0x03, 0x3c, 0x73, 0x43, 0x17, 0xb8, 0xf9, 0x7b, 0xcf, 0x1f, 0x42, 0xb9, 0x39, 0xf2, 0x82, 0x3c, 0x52]
    }
  , TestVector
    { iv : [0x2a, 0x2a, 0x2a, 0x2a]
    , input : [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
    , passphrase : "This is a very long passphrase. This is a very long passphrase. This is a very long passphrase. This is a very long passphrase."
    , shielded_input : [0x2a, 0x2a, 0x2a, 0x2a, 0xa5, 0x97, 0xfe, 0xb5, 0x08, 0xa5, 0x34, 0x06, 0xa3, 0x48, 0xfa, 0xdd, 0x75, 0xc8, 0xa7, 0x02]
    }
  ];

```