### PR TITLE
Allow 96 bits (resp. 9 words) for entropy (resp. mnemonic sentence)

### DIFF
--- a/src/Crypto/Encoding/BIP39/Dictionary.hs
+++ b/src/Crypto/Encoding/BIP39/Dictionary.hs
@@ -133,7 +133,7 @@ newtype MnemonicPhrase (mw :: Nat) = MnemonicPhrase
   deriving (Show, Eq, Ord, Typeable, NormalForm)
 instance ValidMnemonicSentence mw => IsList (MnemonicPhrase mw) where
     type Item (MnemonicPhrase mw) = String
-    fromList = fromMaybe (error "invliad mnemonic phrase") . mnemonicPhrase
+    fromList = fromMaybe (error "invalid mnemonic phrase") . mnemonicPhrase
     toList = ListN.unListN . mnemonicPhraseToListN
 
 mnemonicPhrase :: forall mw . ValidMnemonicSentence mw => [String] -> Maybe (MnemonicPhrase mw)

--- a/src/Crypto/Encoding/BIP39/Dictionary.hs
+++ b/src/Crypto/Encoding/BIP39/Dictionary.hs
@@ -122,7 +122,7 @@ instance ValidMnemonicSentence mw => IsList (MnemonicSentence mw) where
 type ValidMnemonicSentence (mw :: Nat) =
     ( KnownNat mw
     , NatWithinBound Int mw
-    , Elem mw '[12, 15, 18, 21, 24]
+    , Elem mw '[9, 12, 15, 18, 21, 24]
     )
 
 -- | Human readable representation of a 'MnemonicSentence'

--- a/test/Test/Crypto/Encoding/BIP39.hs
+++ b/test/Test/Crypto/Encoding/BIP39.hs
@@ -24,7 +24,8 @@ import Crypto.Encoding.BIP39.English (english)
 
 tests :: Test
 tests = Group "BIP39"
-    [ testsP @128 @12 @4 Proxy
+    [ testsP @96  @9  @3 Proxy
+    , testsP @128 @12 @4 Proxy
     , testsP @160 @15 @5 Proxy
     , testsP @192 @18 @6 Proxy
     , testsP @224 @21 @7 Proxy
@@ -53,6 +54,7 @@ data TestVector = TestVector
 runTest :: TestVector -> Test
 runTest tv =
     case BS.length (testVectorInput tv) * 8 of
+        96  -> go (Proxy @96)
         128 -> go (Proxy @128)
         160 -> go (Proxy @160)
         192 -> go (Proxy @192)


### PR DESCRIPTION
As discussed, this would allow current cardano-sl implementation to fully rely on cardano-crypto BIP39 implementation.
9-word mnemonic sentences were used for the redemption certificates (even though it is a rather small
source of Entropy).