### PR TITLE
[CO-346] BIP39 runtime error

### DIFF
--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -43,6 +43,7 @@ library
                        Crypto.Encoding.BIP39
                        Crypto.Encoding.BIP39.Dictionary
                        Crypto.Encoding.BIP39.English
+                       Cardano.Internal.Compat
   build-depends:       base >= 4.7 && < 5
                      , memory
                      , deepseq

--- a/src/Cardano/Crypto/Encoding/BIP39.hs
+++ b/src/Cardano/Crypto/Encoding/BIP39.hs
@@ -29,8 +29,8 @@ cardanoSlSeed :: forall n csz mw . ConsistentEntropy n mw csz
               -> Maybe Seed
 cardanoSlSeed _ mw =
     case wordsToEntropy @n @csz @mw mw of
-        Nothing -> Nothing
-        Just e -> Just $ BA.convert $ toCbor $ blake2b $ toCbor (entropyRaw e)
+        Left _ -> Nothing
+        Right e -> Just $ BA.convert $ toCbor $ blake2b $ toCbor (entropyRaw e)
   where blake2b :: ByteString -> Digest Blake2b_256
         blake2b = hash
 

--- a/src/Cardano/Crypto/Encoding/Seed.hs
+++ b/src/Cardano/Crypto/Encoding/Seed.hs
@@ -114,8 +114,8 @@ scramble (ScrambleIV iv) e passphrase =
                     salt
         ee = xor otp (entropyRaw e)
      in case toEntropy @entropysizeO (iv <> ee) of
-            Nothing -> error "scramble: the function BIP39.toEntropy returned an unexpected error"
-            Just e' -> e'
+            Left err -> error $ "scramble: the function BIP39.toEntropy returned an error: " <> show err
+            Right e' -> e'
   where
     entropySize = fromIntegral (natVal (Proxy @entropysizeI)) `div` 8
 
@@ -136,8 +136,8 @@ scrambleMnemonic _ iv mw passphrase =
     $ scramble @entropysizeI @entropysizeO iv entropy passphrase
   where
     entropy = case wordsToEntropy @entropysizeI mw of
-        Nothing -> error "mnemonic to entropy failed"
-        Just e  -> e
+        Left  err -> error $ "mnemonic to entropy failed: " <> show err
+        Right e   -> e
 
 -- |
 -- The reverse operation of 'scramble'
@@ -166,8 +166,8 @@ unscramble :: forall entropysizeI entropysizeO mnemonicsize scramblesize csI csO
 unscramble e passphrase =
     let ee = xor otp eraw :: ByteString
      in case toEntropy @entropysizeO ee of
-         Nothing -> error "unscramble: the function BIP39.toEntropy returned an unexpected error"
-         Just e' -> e'
+      Left err -> error $ "unscramble: the function BIP39.toEntropy returned an error: " <> show err
+      Right e' -> e'
   where
     (iv, eraw) = B.splitAt ivSizeBytes (entropyRaw e) :: (ByteString, ByteString)
     salt = iv

--- a/src/Cardano/Internal/Compat.hs
+++ b/src/Cardano/Internal/Compat.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE CPP #-}
+module Cardano.Internal.Compat (fromRight) where
+#if MIN_VERSION_base(4, 10, 0)
+import Data.Either(fromRight)
+#endif
+
+#if !MIN_VERSION_base(4, 10, 0)
+fromRight :: b -> Either a b -> b
+fromRight _ (Right b) = b
+fromRight b _         = b
+#endif

--- a/src/Crypto/Encoding/BIP39.hs
+++ b/src/Crypto/Encoding/BIP39.hs
@@ -62,6 +62,7 @@ import           Basement.String (String)
 import qualified Basement.String as String
 import           Basement.Nat
 import qualified Basement.Sized.List as ListN
+import           Basement.Sized.List (ListN)
 import           Basement.NormalForm
 import           Basement.Compat.Typeable
 import           Basement.Numerical.Number (IsIntegral(..))
@@ -72,7 +73,8 @@ import           Foundation.Check
 import           Control.Monad (replicateM)
 import           Data.Bits
 import           Data.Maybe (fromMaybe)
-import           Data.List (reverse)
+import           Data.List (reverse, intersperse)
+import           Data.Kind (Constraint)
 import           Data.ByteArray (ByteArrayAccess, ByteArray)
 import qualified Data.ByteArray as BA
 import           Data.ByteString (ByteString)
@@ -81,6 +83,7 @@ import qualified Data.ByteString as BS
 import           Data.Proxy
 
 import           GHC.Exts (IsList(..), IsString)
+import           GHC.TypeLits
 
 import           Crypto.Hash (hashWith, SHA256(..))
 import           Crypto.Number.Serialize (os2ip, i2ospOf_)
@@ -290,3 +293,118 @@ phraseToSeed mw dic passphrase =
   where
     sentence = toData $ mnemonicPhraseToString dic mw
     toData = String.toBytes String.UTF8
+
+
+-- -------------------------------------------------------------------------- --
+-- Mnemonic Sentence and Mnemonic Phrase
+-- -------------------------------------------------------------------------- --
+
+-- | Mnemonic Sentence is a list of 'WordIndex'.
+--
+-- This is the generic representation of a mnemonic phrase that can be used for
+-- transalating to a different dictionary (example: English to Japanese).
+--
+-- This is mainly used to convert from/to the 'Entropy' and for 'cardanoSlSeed'
+--
+newtype MnemonicSentence (mw :: Nat) = MnemonicSentence
+    { mnemonicSentenceToListN :: ListN mw WordIndex
+    }
+  deriving (Show, Eq, Ord, Typeable, NormalForm)
+instance ValidMnemonicSentence mw => IsList (MnemonicSentence mw) where
+    type Item (MnemonicSentence mw) = WordIndex
+    fromList = MnemonicSentence . fromMaybe (error "invalid mnemonic size") . ListN.toListN
+    toList = ListN.unListN . mnemonicSentenceToListN
+
+-- | Type Constraint to validate the given 'Nat' is valid for the supported
+-- 'MnemonicSentence'
+type ValidMnemonicSentence (mw :: Nat) =
+    ( KnownNat mw
+    , NatWithinBound Int mw
+    , Elem mw '[9, 12, 15, 18, 21, 24]
+    )
+
+-- | Human readable representation of a 'MnemonicSentence'
+--
+newtype MnemonicPhrase (mw :: Nat) = MnemonicPhrase
+    { mnemonicPhraseToListN :: ListN mw String
+    }
+  deriving (Show, Eq, Ord, Typeable, NormalForm)
+instance ValidMnemonicSentence mw => IsList (MnemonicPhrase mw) where
+    type Item (MnemonicPhrase mw) = String
+    fromList = fromMaybe (error "invalid mnemonic phrase") . mnemonicPhrase
+    toList = ListN.unListN . mnemonicPhraseToListN
+
+mnemonicPhrase :: forall mw . ValidMnemonicSentence mw => [String] -> Maybe (MnemonicPhrase mw)
+mnemonicPhrase l = MnemonicPhrase <$> ListN.toListN l
+{-# INLINABLE mnemonicPhrase #-}
+
+-- | check a given 'MnemonicPhrase' is valid for the given 'Dictionary'
+--
+checkMnemonicPhrase :: forall mw . ValidMnemonicSentence mw
+                    => Dictionary
+                    -> MnemonicPhrase mw
+                    -> Bool
+checkMnemonicPhrase dic (MnemonicPhrase ln) =
+    ListN.foldl' (\acc s -> (dictionaryTestWord dic s && acc)) True ln
+
+-- | convert the given 'MnemonicPhrase' to a generic 'MnemonicSentence'
+-- with the given 'Dictionary'.
+--
+-- This function assumes the 'Dictionary' and the 'MnemonicPhrase' are
+-- compatible (see 'checkMnemonicPhrase').
+--
+mnemonicPhraseToMnemonicSentence :: forall mw . ValidMnemonicSentence mw
+                                 => Dictionary
+                                 -> MnemonicPhrase mw
+                                 -> MnemonicSentence mw
+mnemonicPhraseToMnemonicSentence dic (MnemonicPhrase ln) = MnemonicSentence $
+    ListN.map (dictionaryWordToIndex dic) ln
+
+-- | convert the given generic 'MnemonicSentence' to a human readable
+-- 'MnemonicPhrase' targetting the language of the given 'Dictionary'.
+mnemonicSentenceToMnemonicPhrase :: forall mw . ValidMnemonicSentence mw
+                                 => Dictionary
+                                 -> MnemonicSentence mw
+                                 -> MnemonicPhrase mw
+mnemonicSentenceToMnemonicPhrase dic (MnemonicSentence ln) = MnemonicPhrase $
+    ListN.map (dictionaryIndexToWord dic) ln
+
+mnemonicPhraseToString :: forall mw . ValidMnemonicSentence mw
+                       => Dictionary
+                       -> MnemonicPhrase mw
+                       -> String
+mnemonicPhraseToString dic (MnemonicPhrase ln) = mconcat $
+    intersperse (dictionaryWordSeparator dic) (ListN.unListN ln)
+
+mnemonicSentenceToString :: forall mw . ValidMnemonicSentence mw
+                         => Dictionary
+                         -> MnemonicSentence mw
+                         -> String
+mnemonicSentenceToString dic = mnemonicPhraseToString dic
+                             . mnemonicSentenceToMnemonicPhrase dic
+
+-- | translate the given 'MnemonicPhrase' from one dictionary into another.
+--
+-- This function assumes the source dictionary is compatible with the given
+-- 'MnemonicPhrase' (see 'checkMnemonicPhrase')
+--
+translateTo :: forall mw . ValidMnemonicSentence mw
+            => Dictionary -- ^ source dictionary
+            -> Dictionary -- ^ destination dictionary
+            -> MnemonicPhrase mw
+            -> MnemonicPhrase mw
+translateTo dicSrc dicDst (MnemonicPhrase ln) = MnemonicPhrase $
+    ListN.map (dictionaryIndexToWord dicDst . dictionaryWordToIndex dicSrc) ln
+
+------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------
+
+-- | convenient type level constraint to validate a given 'Nat' e is an elemnt
+-- of the list of 'Nat' l.
+type family Elem (e :: Nat) (l :: [Nat]) :: Constraint where
+    Elem e '[] = TypeError ('Text "offset: field "
+             ':<>: 'ShowType e
+             ':<>: 'Text " not elements of valids values")
+    Elem e (e ': _) = ()
+    Elem e (_ ': xs) = Elem e xs

--- a/src/Crypto/Encoding/BIP39/Dictionary.hs
+++ b/src/Crypto/Encoding/BIP39/Dictionary.hs
@@ -17,6 +17,8 @@ module Crypto.Encoding.BIP39.Dictionary
     , WordIndex
     , wordIndex
     , unWordIndex
+
+    , DictionaryError(..)
     ) where
 
 import           Basement.String (String)
@@ -35,7 +37,7 @@ data Dictionary = Dictionary
     { dictionaryIndexToWord :: WordIndex -> String
       -- ^ This function will retrieve the mnemonic word associated to the
       -- given 'WordIndex'.
-    , dictionaryWordToIndex :: String -> WordIndex
+    , dictionaryWordToIndex :: String -> Either DictionaryError WordIndex
       -- ^ This function will retrieve the 'WordIndex' from a given mnemonic
       -- word.
     , dictionaryTestWord :: String -> Bool
@@ -76,4 +78,12 @@ wordIndex :: Offset String -> WordIndex
 wordIndex w = case tryFrom w of
     Nothing -> error ("Error: word index should be between 0 to 2047. " <> show w)
     Just wi -> wi
+
+-- -------------------------------------------------------------------------- --
+-- Errors
+-- -------------------------------------------------------------------------- --
+
+data DictionaryError
+    = ErrInvalidDictionaryWord String
+    deriving (Show)
 

--- a/src/Crypto/Encoding/BIP39/Dictionary.hs
+++ b/src/Crypto/Encoding/BIP39/Dictionary.hs
@@ -12,43 +12,19 @@
 {-# LANGUAGE OverloadedStrings    #-}
 
 module Crypto.Encoding.BIP39.Dictionary
-    ( -- * Mnemonic Sentence
-      MnemonicSentence(..)
-    , MnemonicPhrase(..)
-    , ValidMnemonicSentence
-    , mnemonicPhrase
-    , checkMnemonicPhrase
-    , mnemonicPhraseToMnemonicSentence
-    , mnemonicSentenceToMnemonicPhrase
-    , mnemonicSentenceToString
-    , mnemonicPhraseToString
-    , translateTo
-    , -- ** Dictionary
+    ( -- ** Dictionary
       Dictionary(..)
     , WordIndex
     , wordIndex
     , unWordIndex
-
-    , Elem
     ) where
 
 import           Basement.String (String)
-import           Basement.Nat
-import           Basement.Sized.List (ListN)
-import qualified Basement.Sized.List as ListN
 import           Basement.NormalForm
 import           Basement.Compat.Typeable
 import           Basement.Types.OffsetSize (Offset(..))
 import           Basement.From (TryFrom(..))
 import           Basement.Imports
-
-import           Data.Maybe (fromMaybe)
-import           Data.List (intersperse)
-
-import           Data.Kind (Constraint)
-
-import           GHC.TypeLits
-import           GHC.Exts (IsList(..))
 
 -- | this discribe the property of the Dictionary and will alllow to
 -- convert from a mnemonic phrase to 'MnemonicSentence'
@@ -101,112 +77,3 @@ wordIndex w = case tryFrom w of
     Nothing -> error ("Error: word index should be between 0 to 2047. " <> show w)
     Just wi -> wi
 
--- | Mnemonic Sentence is a list of 'WordIndex'.
---
--- This is the generic representation of a mnemonic phrase that can be used for
--- transalating to a different dictionary (example: English to Japanese).
---
--- This is mainly used to convert from/to the 'Entropy' and for 'cardanoSlSeed'
---
-newtype MnemonicSentence (mw :: Nat) = MnemonicSentence
-    { mnemonicSentenceToListN :: ListN mw WordIndex
-    }
-  deriving (Show, Eq, Ord, Typeable, NormalForm)
-instance ValidMnemonicSentence mw => IsList (MnemonicSentence mw) where
-    type Item (MnemonicSentence mw) = WordIndex
-    fromList = MnemonicSentence . fromMaybe (error "invalid mnemonic size") . ListN.toListN
-    toList = ListN.unListN . mnemonicSentenceToListN
-
--- | Type Constraint to validate the given 'Nat' is valid for the supported
--- 'MnemonicSentence'
-type ValidMnemonicSentence (mw :: Nat) =
-    ( KnownNat mw
-    , NatWithinBound Int mw
-    , Elem mw '[9, 12, 15, 18, 21, 24]
-    )
-
--- | Human readable representation of a 'MnemonicSentence'
---
-newtype MnemonicPhrase (mw :: Nat) = MnemonicPhrase
-    { mnemonicPhraseToListN :: ListN mw String
-    }
-  deriving (Show, Eq, Ord, Typeable, NormalForm)
-instance ValidMnemonicSentence mw => IsList (MnemonicPhrase mw) where
-    type Item (MnemonicPhrase mw) = String
-    fromList = fromMaybe (error "invalid mnemonic phrase") . mnemonicPhrase
-    toList = ListN.unListN . mnemonicPhraseToListN
-
-mnemonicPhrase :: forall mw . ValidMnemonicSentence mw => [String] -> Maybe (MnemonicPhrase mw)
-mnemonicPhrase l = MnemonicPhrase <$> ListN.toListN l
-{-# INLINABLE mnemonicPhrase #-}
-
--- | check a given 'MnemonicPhrase' is valid for the given 'Dictionary'
---
-checkMnemonicPhrase :: forall mw . ValidMnemonicSentence mw
-                    => Dictionary
-                    -> MnemonicPhrase mw
-                    -> Bool
-checkMnemonicPhrase dic (MnemonicPhrase ln) =
-    ListN.foldl' (\acc s -> (dictionaryTestWord dic s && acc)) True ln
-
--- | convert the given 'MnemonicPhrase' to a generic 'MnemonicSentence'
--- with the given 'Dictionary'.
---
--- This function assumes the 'Dictionary' and the 'MnemonicPhrase' are
--- compatible (see 'checkMnemonicPhrase').
---
-mnemonicPhraseToMnemonicSentence :: forall mw . ValidMnemonicSentence mw
-                                 => Dictionary
-                                 -> MnemonicPhrase mw
-                                 -> MnemonicSentence mw
-mnemonicPhraseToMnemonicSentence dic (MnemonicPhrase ln) = MnemonicSentence $
-    ListN.map (dictionaryWordToIndex dic) ln
-
--- | convert the given generic 'MnemonicSentence' to a human readable
--- 'MnemonicPhrase' targetting the language of the given 'Dictionary'.
-mnemonicSentenceToMnemonicPhrase :: forall mw . ValidMnemonicSentence mw
-                                 => Dictionary
-                                 -> MnemonicSentence mw
-                                 -> MnemonicPhrase mw
-mnemonicSentenceToMnemonicPhrase dic (MnemonicSentence ln) = MnemonicPhrase $
-    ListN.map (dictionaryIndexToWord dic) ln
-
-mnemonicPhraseToString :: forall mw . ValidMnemonicSentence mw
-                       => Dictionary
-                       -> MnemonicPhrase mw
-                       -> String
-mnemonicPhraseToString dic (MnemonicPhrase ln) = mconcat $
-    intersperse (dictionaryWordSeparator dic) (ListN.unListN ln)
-
-mnemonicSentenceToString :: forall mw . ValidMnemonicSentence mw
-                         => Dictionary
-                         -> MnemonicSentence mw
-                         -> String
-mnemonicSentenceToString dic = mnemonicPhraseToString dic
-                             . mnemonicSentenceToMnemonicPhrase dic
-
--- | translate the given 'MnemonicPhrase' from one dictionary into another.
---
--- This function assumes the source dictionary is compatible with the given
--- 'MnemonicPhrase' (see 'checkMnemonicPhrase')
---
-translateTo :: forall mw . ValidMnemonicSentence mw
-            => Dictionary -- ^ source dictionary
-            -> Dictionary -- ^ destination dictionary
-            -> MnemonicPhrase mw
-            -> MnemonicPhrase mw
-translateTo dicSrc dicDst (MnemonicPhrase ln) = MnemonicPhrase $
-    ListN.map (dictionaryIndexToWord dicDst . dictionaryWordToIndex dicSrc) ln
-
-------------------------------------------------------------------------
--- Helpers
-------------------------------------------------------------------------
-
--- | convenient type level constraint to validate a given 'Nat' e is an elemnt
--- of the list of 'Nat' l.
-type family Elem (e :: Nat) (l :: [Nat]) :: Constraint where
-    Elem e '[] = TypeError ('Text "offset: field "
-             ':<>: 'ShowType e
-             ':<>: 'Text " not elements of valids values")
-    Elem e (e ': _) = ()
-    Elem e (_ ': xs) = Elem e xs

--- a/src/Crypto/Encoding/BIP39/English.hs
+++ b/src/Crypto/Encoding/BIP39/English.hs
@@ -10,11 +10,14 @@ import Basement.Sized.Vect
 import Data.Maybe (fromMaybe)
 import qualified Data.List
 
-import Crypto.Encoding.BIP39.Dictionary (Dictionary (..), WordIndex, unWordIndex)
+import Crypto.Encoding.BIP39.Dictionary (Dictionary (..), WordIndex,
+                                         unWordIndex, DictionaryError (..))
 
 english :: Dictionary
 english = Dictionary
-    { dictionaryWordToIndex = fromMaybe undefined . flip Data.List.lookup list
+    { dictionaryWordToIndex = \word -> case Data.List.lookup word list of
+                                           Just x  -> Right x
+                                           Nothing -> Left $ ErrInvalidDictionaryWord word
     , dictionaryTestWord = flip Data.List.elem wordList
     , dictionaryIndexToWord = index words . unWordIndex
     , dictionaryWordSeparator = " "

--- a/test/GoldenTest.hs
+++ b/test/GoldenTest.hs
@@ -22,6 +22,7 @@ import Foundation.String
 import Foundation.String.Read (readIntegral)
 
 import Data.List (elemIndex)
+import Control.Arrow (left)
 
 import Inspector
 import qualified Inspector.TestVector.Types as Type
@@ -206,6 +207,6 @@ instance ValidMnemonicSentence n => Inspectable (Mnemonic 'English n) where
         strs <- words <$> parser v
         Mnemonic <$> case mnemonicPhrase @n strs of
             Nothing -> Left $ "Expected " <> show n <> " words. But received " <> show (length strs) <> " words."
-            Just l  -> pure $ mnemonicPhraseToMnemonicSentence english l
+            Just l  -> left show $ mnemonicPhraseToMnemonicSentence english l
       where
         n = natVal @n Proxy

--- a/test/GoldenTest.hs
+++ b/test/GoldenTest.hs
@@ -206,8 +206,7 @@ instance ValidMnemonicSentence n => Inspectable (Mnemonic 'English n) where
     builder (Mnemonic l) = Value.String $ mnemonicSentenceToString english l
     parser v = do
         strs <- words <$> parser v
-        Mnemonic <$> case mnemonicPhrase @n strs of
-            Nothing -> Left $ "Expected " <> show n <> " words. But received " <> show (length strs) <> " words."
-            Just l  -> left show $ mnemonicPhraseToMnemonicSentence english l
+        phrase <- left show $ mnemonicPhrase @n strs
+        left show $ Mnemonic <$> mnemonicPhraseToMnemonicSentence english phrase
       where
         n = natVal @n Proxy

--- a/test/GoldenTest.hs
+++ b/test/GoldenTest.hs
@@ -36,6 +36,7 @@ import           Cardano.Crypto.Encoding.Seed
 import           Cardano.Crypto.Encoding.BIP39
 import           Crypto.Encoding.BIP39.English (english)
 import qualified Cardano.Crypto.Praos.VRF as VRF
+import           Cardano.Internal.Compat (fromRight)
 
 import Test.Orphans
 
@@ -156,7 +157,7 @@ goldenBIP39 = group $ do
             -> (Entropy n, Seed)
     runTest p (Mnemonic mw) pw  =
         let -- 1. retrieve the entroy
-            entropy = fromMaybe (error "invalid mnemonic phrase")
+            entropy = fromRight (error "invalid mnemonic phrase")
                                 (wordsToEntropy @n mw)
             -- 2. retrieve the seed
             seed = sentenceToSeed @mw mw english pw

--- a/test/Test/Orphans.hs
+++ b/test/Test/Orphans.hs
@@ -148,8 +148,8 @@ instance (BIP39.ValidEntropySize n, BIP39.ValidChecksumSize n csz) => Inspectabl
     parser v = do
         bs <- parser v
         case BIP39.toEntropy (bs :: Bytes) of
-            Nothing -> Left "Expected `Entropy' not the correct size"
-            Just r  -> pure r
+            Left _  -> Left "Expected `Entropy' not the correct size"
+            Right r -> pure r
 
 instance Inspectable BIP39.Seed where
     documentation _ = "BIP39 Seed"


### PR DESCRIPTION
This PR is meant to tackle the runtime error when looking up words that are not in the dictionary. It also takes the opportunity to provide more details in the errors.
<s>
This is done by introducing
```haskell
data BIP39Err
    = BIP39ErrInvalidDictionaryWord String
     | BIP39ErrInvalidEntropyLength
        Int -- ^ Actual length
        Int -- ^ Expected length
     | BIP39ErrInvalidEntropyChecksum
        Word8 -- ^ Actual checksum
        Word8 -- ^ Expected checksum
```

and converting existing `Maybe`-returning and partial functions in the BIP39 module to `Either BIP39Err`.
</s>
Fore some more context, this is how cardano-sl would leverage this: input-output-hk/cardano-sl#3377.

Any thoughts appreciated!

## Linked issue
[CO-346](https://iohk.myjetbrains.com/youtrack/issue/CO-346)

## Thoughts
- Possibly one should ensure that the correct error information is provided from all functions. Particularly there is a risk of switching up the order of the arguments.