### PR TITLE
Buildable on GHC 8.6

### DIFF
--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -1,5 +1,5 @@
 name:                cardano-crypto
-version:             1.1.0
+version:             1.2.0
 synopsis:            Cryptography primitives for cardano
 description:
 homepage:            https://github.com/input-output-hk/cardano-crypto#readme

--- a/src/Crypto/ECC/Ed25519BIP32.hs
+++ b/src/Crypto/ECC/Ed25519BIP32.hs
@@ -301,7 +301,7 @@ step2 z = (8 * zeroExtendedZl, Bytes.toBits Bytes.LittleEndian zRight)
     zl :: Bytes 28 -- only take 28 bytes
     zl = Bytes.take zLeft32
 
-    zeroExtender :: FBits (4*8) -- re-extend by 4 bytes
+    zeroExtender :: FBits (4 GHC.TypeLits.* 8) -- re-extend by 4 bytes
     zeroExtender = 0
 
 -- | Serialized index

--- a/src/Crypto/Math/Bits.hs
+++ b/src/Crypto/Math/Bits.hs
@@ -31,7 +31,7 @@ data FBits (n :: Nat) = FBits { unFBits :: Natural }
 
 data FBitsK = FBitsK (forall n . (KnownNat n, SizeValid n) => FBits n)
 
-type SizeValid n = (KnownNat n, 1 <= n)
+type SizeValid (n :: Nat) = (KnownNat n, 1 <= n)
 
 toFBits :: SizeValid n => Natural -> FBits n
 toFBits nat = FBits nat .&. allOne
@@ -81,7 +81,8 @@ allOne :: forall n . SizeValid n => FBits n
 allOne = FBits (2 ^ n - 1)
   where n = natVal (Proxy :: Proxy n)
 
-splitHalf :: forall m n . (SizeValid n, (n * 2) ~ m) => FBits m -> (FBits n, FBits n)
+splitHalf :: forall (m :: Nat) (n :: Nat) . (SizeValid n, (n GHC.TypeLits.* 2) ~ m)
+          => FBits m -> (FBits n, FBits n)
 splitHalf (FBits a) = (FBits (a `shiftR` n), toFBits a)
   where n = fromIntegral $ natVal (Proxy :: Proxy n)
 
@@ -89,7 +90,7 @@ splitHalf (FBits a) = (FBits (a `shiftR` n), toFBits a)
 -- element.
 --
 -- e.g. append (0x1 :: FBits 1) (0x70 :: FBits 7) = 0xf0 :: FBits 8
-append :: forall m n r . (SizeValid m, SizeValid n, SizeValid r, (m + n) ~ r)
+append :: forall (m :: Nat) (n :: Nat) r . (SizeValid m, SizeValid n, SizeValid r, (m + n) ~ r)
        => FBits n -> FBits m -> FBits r
 append (FBits a) (FBits b) =
     FBits ((a `shiftL` m) .|.  b)

--- a/src/Crypto/Math/Bytes.hs
+++ b/src/Crypto/Math/Bytes.hs
@@ -66,7 +66,7 @@ trace cmd b@(Bytes l) = Trace.trace (cmd ++ ": " ++ concatMap toHex l) b
           | otherwise = toEnum (fromEnum 'a' + fromIntegral (i-10))
 
 -- | transform bytes into bits with a specific endianness
-toBits :: Endian -> Bytes n -> FBits (n * 8)
+toBits :: Endian -> Bytes n -> FBits (n GHC.TypeLits.* 8)
 toBits endian (Bytes l) = FBits $
     foldl' (\acc i -> (acc `shiftL` 8) + fromIntegral i) 0 (fixupBytes endian l)
 
@@ -86,7 +86,7 @@ fromBits endian (unFBits -> allBits) = Bytes $ loop [] (0 :: Word) allBits
     divMod8 i = let (q,m) = i `divMod` 256 in (q,fromIntegral m)
 
 
-splitHalf :: forall m n . (KnownNat n, (n * 2) ~ m) => Bytes m -> (Bytes n, Bytes n)
+splitHalf :: forall m n . (KnownNat n, (n GHC.TypeLits.* 2) ~ m) => Bytes m -> (Bytes n, Bytes n)
 splitHalf (Bytes l) = (Bytes l1, Bytes l2)
   where
     (l1, l2) = splitAt n l


### PR DESCRIPTION
https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#StarIsType

In 8.6, the star * is interpreted as `Type` always. This patch makes it build on 8.6 by using the qualified name `GHC.TypeLits.*`.