### PR TITLE
Turn on `NoStarIsType` for GHC 8.6

### DIFF
--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -61,6 +61,8 @@ library
   default-extensions:  GeneralizedNewtypeDeriving
   ghc-options:         -Wall
   cc-options:          -Wall -Wno-unused-function
+  if impl(ghc >= 8.6)
+    default-extensions: NoStarIsType
 
 test-suite cardano-crypto-test
   type:                exitcode-stdio-1.0

--- a/src/Crypto/ECC/Ed25519BIP32.hs
+++ b/src/Crypto/ECC/Ed25519BIP32.hs
@@ -21,6 +21,7 @@ import qualified Crypto.MAC.HMAC as C
 import qualified Data.ByteArray as B
 import qualified Data.ByteString as BS
 import           Data.Bits
+import           Data.Kind (Type)
 import           Data.Word
 import           Data.Proxy
 import qualified Crypto.Math.Edwards25519 as ED25519
@@ -89,15 +90,15 @@ type MinHardIndex = 0x80000000
 type MaxSoftIndex = MinHardIndex - 1
 type MinSoftIndex = 0
 
-data ValidIndex :: Nat -> * where
+data ValidIndex :: Nat -> Type where
     IsValidIndex    :: (ValidDerivationIndex n :~: 'True) -> ValidIndex n
     IsNotValidIndex :: (ValidDerivationIndex n :~: 'False) -> ValidIndex n
 
-data ValidHardIndex :: Nat -> * where
+data ValidHardIndex :: Nat -> Type where
     IsValidHardIndex    :: (ValidDerivationHardIndex n :~: 'True) -> ValidHardIndex n
     IsNotValidHardIndex :: (ValidDerivationHardIndex n :~: 'False) -> ValidHardIndex n
 
-data ValidSoftIndex :: Nat -> * where
+data ValidSoftIndex :: Nat -> Type where
     IsValidSoftIndex    :: (ValidDerivationSoftIndex n :~: 'True) -> ValidSoftIndex n
     IsNotValidSoftIndex :: (ValidDerivationSoftIndex n :~: 'False) -> ValidSoftIndex n
 


### PR DESCRIPTION
This implements the alternate fix for building on GHC 8.6