### PR TITLE
Forcebly sets utf8 encoding on windows

### DIFF
--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -93,6 +93,7 @@ test-suite cardano-crypto-golden-tests
   hs-source-dirs:      test
   main-is:             GoldenTest.hs
   other-modules:       Test.Orphans
+                     , Encoding
   build-depends:       base
                      , basement
                      , foundation

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -113,6 +113,7 @@ executable golden-tests
   hs-source-dirs:      test
   main-is:             GoldenTest.hs
   other-modules:       Test.Orphans
+                     , Encoding
   if flag(golden-tests-exe)
     build-depends:     inspector
     buildable:         True

--- a/test/Encoding.hs
+++ b/test/Encoding.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE CPP #-}
+
+module Encoding (setEncoding) where
+
+#if mingw32_HOST_OS
+import           System.IO (IO, hSetEncoding, stdout, stderr, utf8)
+#endif
+
+setEncoding :: IO ()
+#if mingw32_HOST_OS
+setEncoding = do
+  hSetEncoding stdout utf8
+  hSetEncoding stderr utf8
+#else
+setEncoding = return ()
+#endif

--- a/test/Encoding.hs
+++ b/test/Encoding.hs
@@ -3,10 +3,9 @@
 module Encoding (setEncoding) where
 
 #if mingw32_HOST_OS
-import           System.IO (IO, hSetEncoding, stdout, stderr, utf8)
+import           System.IO (hSetEncoding, stdout, stderr, utf8)
 #endif
 
-setEncoding :: IO ()
 #if mingw32_HOST_OS
 setEncoding = do
   hSetEncoding stdout utf8

--- a/test/GoldenTest.hs
+++ b/test/GoldenTest.hs
@@ -40,8 +40,12 @@ import           Cardano.Internal.Compat (fromRight)
 
 import Test.Orphans
 
+import           Encoding (setEncoding)
+
 main :: IO ()
-main = defaultTest $ do
+main = do
+  setEncoding
+  defaultTest $ do
     goldenSignatureEd25519
     goldenBIP39
     goldenHDWallet


### PR DESCRIPTION
As the result of defaultTest expects to be
able to write utf-8 to stdout/stderr, we
ensure that their encoding is set accordingly.

This should fix failures like:
```
cardano-crypto-golden-tests.exe: <stdout>: commitBuffer: invalid
argument (invalid character)
```

Note the addition of the Encoding module. This is
necessary as multi-line strings (in GoldenTests.hs)
do not mix well with CPP.