### PR TITLE
Fix hardened derivation boundary for deriveXPub

### DIFF
--- a/src/Cardano/Crypto/Wallet.hs
+++ b/src/Cardano/Crypto/Wallet.hs
@@ -166,8 +166,8 @@ deriveXPrv ds passPhrase (XPrv ekey) n =
 -- | Derive a child extended public key from an extended public key
 deriveXPub :: DerivationScheme -> XPub -> Word32 -> Maybe XPub
 deriveXPub ds (XPub pub (ChainCode cc)) n
-    | n >= 0x8000000 = Nothing
-    | otherwise      = Just $ uncurry XPub $ second ChainCode $ encryptedDerivePublic ds (pub,cc) n
+    | n >= 0x80000000 = Nothing
+    | otherwise       = Just $ uncurry XPub $ second ChainCode $ encryptedDerivePublic ds (pub,cc) n
 
 sign :: (ByteArrayAccess passPhrase, ByteArrayAccess msg)
      => passPhrase


### PR DESCRIPTION
According to bip32 (revision 24 Feb 2017) deriveXPub is not
defined for hardened child indices. Hardened child  is defined
 as (>= 0x80000000). Our implementation had one zero dropped from
 hex representation of hardened child index boundary.

More info here: https://github.com/input-output-hk/cardano-wallet/pull/133#discussion_r , where the mistake was found with quickcheck property test (which also accidentily dropped one zero)

Long term maybe it would be wise to refactor and not harcode this value in multiple places. 

This module might have a constant or function like this defined https://github.com/input-output-hk/cardano-wallet/pull/170/files#diff-ab6bdce941f09e40581d4a2debad9d7aR37 . This change is not crutial though, but nice to have so I left it out for now