### PR TITLE
Upgrade to cabal-3.4.0.0 rc5 on Windows for better caching.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.2"]
+        ghc: ["8.6.5", "8.10.3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -35,11 +35,18 @@ jobs:
     - name: Select build directory
       run: echo "CABAL_BUILDDIR=dist" >> $GITHUB_ENV
 
-    - uses: actions/setup-haskell@v1
+    - name: Select optimal cabal version
+      run: |
+        case "$OS" in
+          Windows_NT)   echo "CABAL_VERSION=3.4.0.0-rc5"  >> $GITHUB_ENV;;
+          *)            echo "CABAL_VERSION=3.4.0.0-rc4"  >> $GITHUB_ENV;;
+        esac
+
+    - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2.0.0'
+        cabal-version: ${{ env.CABAL_VERSION }}
 
     - name: Cabal update
       run: cabal update
@@ -47,15 +54,21 @@ jobs:
     - name: Cabal Configure
       run: cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
+    - name: Record dependencies
+      run: |
+        cat ${{ env.PLAN_JSON }} | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
+
+    - name: Set cache version
+      run: echo "CACHE_VERSION=9w76Z3Q" >> $GITHUB_ENV
+
     - uses: actions/cache@v2
-      if: matrix.os != 'macos-latest'
       name: Cache cabal store
       with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist
-        key: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
-        restore-keys: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key: cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        restore-keys: |
+          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Install dependencies
       run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2017 IOHK
+Copyright (c) 2016-2021 IOHK
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -7,7 +7,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Vincent Hanquez
 maintainer:          contact@typed.io
-copyright:           2016-2017 IOHK
+copyright:           2016-2021 IOHK
 category:            Crypto
 build-type:          Simple
 extra-source-files:  README.md


### PR DESCRIPTION
This for better caching of cabal cache.

Also:

* Introduce CACHE_VERSION to make it possible to invalidate cache.
* Introduce dependencies.txt which will cause new cache to be generated when dependencies changed.
* Upgrade to ghc-8.10.3 in Github Actions.