### PR TITLE
Upgrade to cabal-3.4.0.0

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.3"]
+        ghc: ["8.10.4"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            ghc: 8.6.5
 
     steps:
     - uses: actions/checkout@v1
@@ -35,13 +32,6 @@ jobs:
     - name: Select build directory
       run: echo "CABAL_BUILDDIR=dist" >> $GITHUB_ENV
 
-    - name: Select optimal cabal version
-      run: |
-        case "$OS" in
-          Windows_NT)   echo "CABAL_VERSION=3.4.0.0-rc5"  >> $GITHUB_ENV;;
-          *)            echo "CABAL_VERSION=3.4.0.0"      >> $GITHUB_ENV;;
-        esac
-
     - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
@@ -52,11 +42,11 @@ jobs:
       run: cabal update
 
     - name: Cabal Configure
-      run: cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
+      run: cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
     - name: Record dependencies
       run: |
-        cat ${{ env.PLAN_JSON }} | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
+        cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
     - name: Set cache version
       run: echo "CACHE_VERSION=9w76Z3Q" >> $GITHUB_ENV
@@ -71,13 +61,13 @@ jobs:
           cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Install dependencies
-      run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+      run: cabal build all --only-dependencies
 
     - name: Build
-      run: cabal build all --builddir="$CABAL_BUILDDIR"
+      run: cabal build all
 
     - name: Adjust golden files
       run: find tests/goldens -type f | xargs dos2unix
 
     - name: Run tests
-      run: cabal test all --builddir="$CABAL_BUILDDIR"
+      run: cabal test all


### PR DESCRIPTION
Drop support for `ghc-8.6.5`.
Remove `--builddir` work around which is not needed for `ghc-8.10.x` onwards.