### PR TITLE
Switch from cryptonite library to crypton and fix cbits

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install dos2unix (MacOS)
       if: matrix.os == 'macos-latest'
-      run: brew install dos2unix
+      run: brew install dos2unix llvm@13
 
     - name: Select build directory
       run: echo "CABAL_BUILDDIR=dist" >> $GITHUB_ENV

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Select build directory
       run: echo "CABAL_BUILDDIR=dist" >> $GITHUB_ENV
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.10.1.0
+        # cabal-version: 3.10.1.0
 
     - name: Cabal update
       run: cabal update

--- a/cabal.project
+++ b/cabal.project
@@ -12,9 +12,10 @@ repository cardano-haskell-packages
 
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
-  , hackage.haskell.org 2023-05-16T01:25:23Z
+  , hackage.haskell.org 2024-10-10T00:52:24Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-05-16T08:53:30Z
+  , cardano-haskell-packages 2024-10-10T04:22:19Z
+
 
 packages: .
 
@@ -32,4 +33,4 @@ source-repository-package
   type: git
   -- Forked from https://github.com/primetype/inspector
   location: https://github.com/input-output-hk/inspector
-  tag: 962c6b5b52b760eeeb847d318800392be9aab5fa
+  tag: e13c4fde2f8c1cb908328e6a6e82db6cf16dd037

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -49,7 +49,7 @@ library
                      , bytestring
                      , basement
                      , foundation
-                     , cryptonite >= 0.22
+                     , crypton >= 0.22
                      , hashable
                      , integer-gmp
   default-language:    Haskell2010
@@ -77,7 +77,7 @@ test-suite cardano-crypto-test
   build-depends:       base
                      , bytestring
                      , memory
-                     , cryptonite
+                     , crypton
                      , cardano-crypto
                      , basement
                      , foundation
@@ -94,7 +94,7 @@ test-suite cardano-crypto-golden-tests
                      , foundation
                      , memory
                      , bytestring
-                     , cryptonite
+                     , crypton
                      , cardano-crypto
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-extensions:  NoImplicitPrelude
@@ -119,7 +119,7 @@ executable golden-tests
                      , foundation
                      , memory
                      , bytestring
-                     , cryptonite
+                     , crypton
                      , cardano-crypto
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-extensions:  NoImplicitPrelude
@@ -132,7 +132,7 @@ benchmark cardano-crypto-bench
   build-depends:       base
                      , bytestring
                      , memory
-                     , cryptonite
+                     , crypton
                      , cardano-crypto
                      , gauge
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -1,5 +1,5 @@
 name:                cardano-crypto
-version:             1.1.2
+version:             1.1.3
 synopsis:            Cryptography primitives for cardano
 description:
 homepage:            https://github.com/input-output-hk/cardano-crypto#readme

--- a/cbits/crypton_pbkdf2.h
+++ b/cbits/crypton_pbkdf2.h
@@ -8,17 +8,17 @@
 extern "C" {
 #endif
 
-void cryptonite_fastpbkdf2_hmac_sha1( const uint8_t *pw, size_t npw
+void crypton_fastpbkdf2_hmac_sha1( const uint8_t *pw, size_t npw
                                     , const uint8_t *salt, size_t nsalt
                                     , uint32_t iterations
                                     , uint8_t *out, size_t nout
                                     );
-void cryptonite_fastpbkdf2_hmac_sha256( const uint8_t *pw, size_t npw
+void crypton_fastpbkdf2_hmac_sha256( const uint8_t *pw, size_t npw
                                       , const uint8_t *salt, size_t nsalt
                                       , uint32_t iterations
                                       , uint8_t *out, size_t nout
                                       );
-void cryptonite_fastpbkdf2_hmac_sha512( const uint8_t *pw, size_t npw
+void crypton_fastpbkdf2_hmac_sha512( const uint8_t *pw, size_t npw
                                       , const uint8_t *salt, size_t nsalt
                                       , uint32_t iterations
                                       , uint8_t *out, size_t nout

--- a/cbits/crypton_sha512.h
+++ b/cbits/crypton_sha512.h
@@ -43,17 +43,17 @@ struct sha512_ctx
 #define SHA512_DIGEST_SIZE	64
 #define SHA512_CTX_SIZE		sizeof(struct sha512_ctx)
 
-void cryptonite_sha384_init(struct sha384_ctx *ctx);
-void cryptonite_sha384_update(struct sha384_ctx *ctx, const uint8_t *data, uint32_t len);
-void cryptonite_sha384_finalize(struct sha384_ctx *ctx, uint8_t *out);
+void crypton_sha384_init(struct sha384_ctx *ctx);
+void crypton_sha384_update(struct sha384_ctx *ctx, const uint8_t *data, uint32_t len);
+void crypton_sha384_finalize(struct sha384_ctx *ctx, uint8_t *out);
 
-void cryptonite_sha512_init(struct sha512_ctx *ctx);
-void cryptonite_sha512_update(struct sha512_ctx *ctx, const uint8_t *data, uint32_t len);
-void cryptonite_sha512_finalize(struct sha512_ctx *ctx, uint8_t *out);
+void crypton_sha512_init(struct sha512_ctx *ctx);
+void crypton_sha512_update(struct sha512_ctx *ctx, const uint8_t *data, uint32_t len);
+void crypton_sha512_finalize(struct sha512_ctx *ctx, uint8_t *out);
 
 /* only multiples of 8 are supported as valid t values */
-void cryptonite_sha512t_init(struct sha512_ctx *ctx, uint32_t hashlen);
-void cryptonite_sha512t_update(struct sha512_ctx *ctx, const uint8_t *data, uint32_t len);
-void cryptonite_sha512t_finalize(struct sha512_ctx *ctx, uint32_t hashlen, uint8_t *out);
+void crypton_sha512t_init(struct sha512_ctx *ctx, uint32_t hashlen);
+void crypton_sha512t_update(struct sha512_ctx *ctx, const uint8_t *data, uint32_t len);
+void crypton_sha512t_finalize(struct sha512_ctx *ctx, uint32_t hashlen, uint8_t *out);
 
 #endif

--- a/cbits/ed25519/ed25519-hash.h
+++ b/cbits/ed25519/ed25519-hash.h
@@ -1,26 +1,26 @@
-#include <cryptonite_sha512.h>
+#include <crypton_sha512.h>
 typedef struct sha512_ctx ed25519_hash_context;
 
 static void
 ed25519_hash_init(ed25519_hash_context *ctx) {
-	cryptonite_sha512_init(ctx);
+	crypton_sha512_init(ctx);
 }
 
 static void
 ed25519_hash_update(ed25519_hash_context *ctx, const uint8_t *in, size_t inlen) {
-	cryptonite_sha512_update(ctx, in, inlen);
+	crypton_sha512_update(ctx, in, inlen);
 }
 
 static void
 ed25519_hash_final(ed25519_hash_context *ctx, uint8_t *hash) {
-	cryptonite_sha512_finalize(ctx, hash);
+	crypton_sha512_finalize(ctx, hash);
 }
 
 static void
 ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
 	ed25519_hash_context ctx;
-	cryptonite_sha512_init(&ctx);
-	cryptonite_sha512_update(&ctx, in, inlen);
-	cryptonite_sha512_finalize(&ctx, hash);
+	crypton_sha512_init(&ctx);
+	crypton_sha512_update(&ctx, in, inlen);
+	crypton_sha512_finalize(&ctx, hash);
 	memset(&ctx, 0, sizeof(ctx));
 }

--- a/cbits/encrypted_sign.c
+++ b/cbits/encrypted_sign.c
@@ -5,12 +5,12 @@
 #include <ed25519.h>
 #include <hmac.h>
 
-#include "cryptonite_pbkdf2.h"
+#include "crypton_pbkdf2.h"
 
-typedef uint8_t cryptonite_chacha_context[131];
+typedef uint8_t crypton_chacha_context[131];
 
-extern void cryptonite_chacha_init(cryptonite_chacha_context *ctx, uint8_t nb_rounds, uint32_t keylen, const uint8_t *key, uint32_t ivlen, const uint8_t *iv);
-extern void cryptonite_chacha_combine(uint8_t *dst, cryptonite_chacha_context *st, const uint8_t *src, uint32_t bytes);
+extern void crypton_chacha_init(crypton_chacha_context *ctx, uint8_t nb_rounds, uint32_t keylen, const uint8_t *key, uint32_t ivlen, const uint8_t *iv);
+extern void crypton_chacha_combine(uint8_t *dst, crypton_chacha_context *st, const uint8_t *src, uint32_t bytes);
 
 void clear(void *buf, uint32_t const sz)
 {
@@ -25,7 +25,7 @@ void stretch(uint8_t *buf, uint32_t const buf_len, uint8_t const *pass, uint32_t
 {
 	const uint8_t salt[] = "encrypted wallet salt";
 	assert(pass_len > 0);
-	cryptonite_fastpbkdf2_hmac_sha512(pass, pass_len, salt, sizeof(salt), NB_ITERATIONS, buf, buf_len);
+	crypton_fastpbkdf2_hmac_sha512(pass, pass_len, salt, sizeof(salt), NB_ITERATIONS, buf, buf_len);
 }
 
 #define SYM_KEY_SIZE     32
@@ -53,18 +53,18 @@ typedef struct {
 static void memory_combine(uint8_t const *pass, uint32_t const pass_len, uint8_t const *source, uint8_t *dest, uint32_t sz)
 {
 	uint8_t buf[SYM_BUF_SIZE];
-	cryptonite_chacha_context ctx;
+	crypton_chacha_context ctx;
 	static uint8_t const CHACHA_NB_ROUNDS = 20;
 
 	if (pass_len) {
-		memset(&ctx, 0, sizeof(cryptonite_chacha_context));
+		memset(&ctx, 0, sizeof(crypton_chacha_context));
 
 		/* generate BUF_SIZE bytes where first KEY_SIZE bytes is the key and NONCE_SIZE remaining bytes the nonce */
 		stretch(buf, SYM_BUF_SIZE, pass, pass_len);
-		cryptonite_chacha_init(&ctx, CHACHA_NB_ROUNDS, SYM_KEY_SIZE, buf, SYM_NONCE_SIZE, buf + SYM_KEY_SIZE);
+		crypton_chacha_init(&ctx, CHACHA_NB_ROUNDS, SYM_KEY_SIZE, buf, SYM_NONCE_SIZE, buf + SYM_KEY_SIZE);
 		clear(buf, SYM_BUF_SIZE);
-		cryptonite_chacha_combine(dest, &ctx, source, sz);
-		clear(&ctx, sizeof(cryptonite_chacha_context));
+		crypton_chacha_combine(dest, &ctx, source, sz);
+		clear(&ctx, sizeof(crypton_chacha_context));
 	} else {
 		memcpy(dest, source, sz);
 	}
@@ -158,9 +158,9 @@ DECL_HMAC(sha512,
           SHA512_BLOCK_SIZE,
           SHA512_DIGEST_SIZE,
           struct sha512_ctx,
-          cryptonite_sha512_init,
-          cryptonite_sha512_update,
-          cryptonite_sha512_finalize);
+          crypton_sha512_init,
+          crypton_sha512_update,
+          crypton_sha512_finalize);
 
 typedef enum {
 	DERIVATION_V1 = 1,

--- a/cbits/encrypted_sign.c
+++ b/cbits/encrypted_sign.c
@@ -253,9 +253,9 @@ static void serialize_index32(uint8_t *out, uint32_t index, derivation_scheme_mo
 
 static void add_left(ed25519_secret_key res_key, uint8_t *z, ed25519_secret_key priv_key, derivation_scheme_mode mode)
 {
-	uint8_t zl8[32];
+	ed25519_secret_key zl8;
 
-	memset(zl8, 0, 32);
+	memset(zl8, 0, 64);
 	switch (mode) {
 	case DERIVATION_V1:
 		/* get 8 * Zl */
@@ -287,10 +287,10 @@ static void add_right(ed25519_secret_key res_key, uint8_t *z, ed25519_secret_key
 
 static void add_left_public(uint8_t *out, uint8_t *z, uint8_t *in, derivation_scheme_mode mode)
 {
-	uint8_t zl8[32];
+	ed25519_secret_key zl8;
 	ed25519_public_key pub_zl8;
 
-	memset(zl8, 0, 32);
+	memset(zl8, 0, 64);
 	switch (mode) {
 	case DERIVATION_V1:
 		multiply8_v1(zl8, z, 32);

--- a/cbits/hmac.h
+++ b/cbits/hmac.h
@@ -1,7 +1,7 @@
 #ifndef HMAC_H
 #define HMAC_H
 
-#include "cryptonite_sha512.h"
+#include "crypton_sha512.h"
 
 #define HMAC_CTX(_name) HMAC_ ## _name ## _ctx
 #define HMAC_INIT(_name) HMAC_ ## _name ## _init


### PR DESCRIPTION
* The cryptonite library is deprecated and has been replaced by crypton which is a drop in replacement.

* cbits: Squash a Wstringop-overread error (This needs very careful review).