### PR TITLE
Provide cabal bounds in compliance with hackage requirements

### DIFF
--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -1,7 +1,7 @@
 name:                cardano-crypto
 version:             1.2.0
 synopsis:            Cryptography primitives for cardano
-description:
+description:         This package provide cryptographic primitives in use in the Cardano network, mostly related to legacy Byron era.
 homepage:            https://github.com/input-output-hk/cardano-crypto#readme
 license:             MIT
 license-file:        LICENSE
@@ -44,14 +44,14 @@ library
                        Crypto.Encoding.BIP39.English
                        Cardano.Internal.Compat
   build-depends:       base >= 4.7 && < 5
-                     , memory
-                     , deepseq
-                     , bytestring
-                     , basement
-                     , foundation
-                     , crypton >= 0.22
-                     , hashable
-                     , integer-gmp
+                     , basement >= 0.0.16 && < 0.1
+                     , bytestring >= 0.11.5 && < 0.13
+                     , crypton >= 0.32 && <= 1.0.1
+                     , deepseq >= 1.4.8 && < 1.6
+                     , foundation >= 0.0.30 && < 0.1
+                     , integer-gmp >= 1.1 && < 1.2
+                     , hashable >= 1.5.0 && < 1.6
+                     , memory >= 0.18.0 && < 0.19
   default-language:    Haskell2010
   C-sources:           cbits/ed25519/ed25519.c
                        cbits/encrypted_sign.c

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -44,14 +44,14 @@ library
                        Crypto.Encoding.BIP39.English
                        Cardano.Internal.Compat
   build-depends:       base >= 4.7 && < 5
-                     , basement >= 0.0.16 && < 0.1
-                     , bytestring >= 0.11.5 && < 0.13
-                     , crypton >= 0.32 && <= 1.0.1
-                     , deepseq >= 1.4.8 && < 1.6
-                     , foundation >= 0.0.30 && < 0.1
-                     , integer-gmp >= 1.1 && < 1.2
-                     , hashable >= 1.5.0 && < 1.6
-                     , memory >= 0.18.0 && < 0.19
+                     , basement >= 0.0.16
+                     , bytestring >= 0.11
+                     , crypton >= 0.32 && < 1.1
+                     , deepseq
+                     , foundation
+                     , integer-gmp
+                     , hashable >= 1.4 && < 1.6
+                     , memory >= 0.18
   default-language:    Haskell2010
   C-sources:           cbits/ed25519/ed25519.c
                        cbits/encrypted_sign.c


### PR DESCRIPTION
This small PR is intended as preparatory step to upload cardano-crypto to hackage.haskell.org, which is itself a pre-requisite to upload cardano-addresses to Hackage.
See https://hackage.haskell.org/package/cardano-crypto-1.2.0/candidate for how it would look like on Hackage.

#99 