### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,21 +1,6 @@
--- Custom repository for cardano haskell packages, see CONTRIBUTING for more
-repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
-  secure: True
-  root-keys:
-    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
-    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
-    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
-    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
-    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
-    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
-
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
   , hackage.haskell.org 2025-01-16T03:16:46Z
-  -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2025-01-15T09:59:24Z
-
 
 packages: .
 

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -1,5 +1,5 @@
 name:                cardano-crypto
-version:             1.2.0
+version:             1.3.0
 synopsis:            Cryptography primitives for cardano
 description:         This package provide cryptographic primitives in use in the Cardano network, mostly related to legacy Byron era.
 homepage:            https://github.com/input-output-hk/cardano-crypto#readme


### PR DESCRIPTION
There's already a 1.2.0 version on CHaP, so in order to publish cardano-crypto on Hackaage (which is needed for cardano-addresses to be published on Hackage), we want to prevent potential conflicts to happen.

This also removes dependency on CHaP from the `cabal.project` to guarantee the project can be built with dependencies drawn only from Hackage.