### PR TITLE
Maintenance updates

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "9.6", "9.8", "9.10", "9.12" ]
+        ghc: [ "9.6", "9.8", "9.10", "9.12", "9.14" ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
-  , hackage.haskell.org 2025-06-09T20:31:03Z
+  , hackage.haskell.org 2026-07-23T03:55:38Z
 
 packages: .
 
@@ -19,7 +19,7 @@ source-repository-package
   type: git
   -- Forked from https://github.com/primetype/inspector
   location: https://github.com/input-output-hk/inspector
-  tag: c36bdeb52341d149c8e5fda8d42e1eb85f57f0e9
+  tag: 6da7d100a151306269c269844f7571ccc05e4815
 
 if impl (ghc >= 9.10)
   allow-newer:

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -1,5 +1,5 @@
 name:                cardano-crypto
-version:             1.3.0
+version:             1.4.0
 synopsis:            Cryptography primitives for cardano
 description:         This package provide cryptographic primitives in use in the Cardano network, mostly related to legacy Byron era.
 homepage:            https://github.com/input-output-hk/cardano-crypto#readme

--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -13,7 +13,7 @@ build-type:          Simple
 extra-source-files:  README.md
                      cbits/*.h
                      cbits/ed25519/*.h
-cabal-version:       >=1.10
+cabal-version:       >=2.0
 
 flag golden-tests
   description:       compile the golden tests and run them
@@ -43,15 +43,17 @@ library
                        Crypto.Encoding.BIP39.Dictionary
                        Crypto.Encoding.BIP39.English
                        Cardano.Internal.Compat
+  other-modules:       Compat.ByteArray
   build-depends:       base >= 4.7 && < 5
+                     , array
                      , basement >= 0.0.16
                      , bytestring >= 0.11
-                     , crypton >= 0.32 && < 1.1
+                     , crypton ^>= 1.1
                      , deepseq
                      , foundation
                      , integer-gmp
                      , hashable >= 1.4 && < 1.6
-                     , memory >= 0.18
+                     , ram >= 0.22
   default-language:    Haskell2010
   C-sources:           cbits/ed25519/ed25519.c
                        cbits/encrypted_sign.c
@@ -76,7 +78,7 @@ test-suite cardano-crypto-test
                        Utils
   build-depends:       base
                      , bytestring
-                     , memory
+                     , ram
                      , crypton
                      , cardano-crypto
                      , basement
@@ -92,7 +94,7 @@ test-suite cardano-crypto-golden-tests
   build-depends:       base
                      , basement
                      , foundation
-                     , memory
+                     , ram
                      , bytestring
                      , crypton
                      , cardano-crypto
@@ -117,7 +119,7 @@ executable golden-tests
   build-depends:       base
                      , basement
                      , foundation
-                     , memory
+                     , ram
                      , bytestring
                      , crypton
                      , cardano-crypto
@@ -131,7 +133,7 @@ benchmark cardano-crypto-bench
   Main-is:             Bench.hs
   build-depends:       base
                      , bytestring
-                     , memory
+                     , ram
                      , crypton
                      , cardano-crypto
                      , gauge

--- a/src/Cardano/Crypto/Encoding/Seed.hs
+++ b/src/Cardano/Crypto/Encoding/Seed.hs
@@ -58,6 +58,8 @@ import           Basement.Sized.List (ListN)
 import qualified Basement.Sized.List as ListN
 import Data.ByteArray (ByteArrayAccess)
 
+import Prelude (type (~))
+
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 

--- a/src/Cardano/Crypto/Encoding/Seed.hs
+++ b/src/Cardano/Crypto/Encoding/Seed.hs
@@ -52,6 +52,7 @@ import Basement.Nat
 import Crypto.Error
 
 import Data.ByteArray (xor, ScrubbedBytes)
+import Compat.ByteArray (AsBytes (..))
 import Crypto.Encoding.BIP39
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import           Basement.Sized.List (ListN)
@@ -112,7 +113,7 @@ scramble (ScrambleIV iv) e passphrase =
         otp :: ScrubbedBytes
         otp = PBKDF2.fastPBKDF2_SHA512
                     (PBKDF2.Parameters iterations entropySize)
-                    passphrase
+                    (AsBytes passphrase)
                     salt
         ee = xor otp (entropyRaw e)
      in case toEntropy @entropysizeO (iv <> ee) of
@@ -176,6 +177,6 @@ unscramble e passphrase =
     otp :: ScrubbedBytes
     otp = PBKDF2.fastPBKDF2_SHA512
                   (PBKDF2.Parameters iterations entropySize)
-                  passphrase
+                  (AsBytes passphrase)
                   salt
     entropySize = fromIntegral (natVal (Proxy @entropysizeO)) `div` 8

--- a/src/Cardano/Crypto/Encoding/Seed.hs
+++ b/src/Cardano/Crypto/Encoding/Seed.hs
@@ -73,7 +73,7 @@ iterations :: Int
 iterations = 10000
 
 newtype ScrambleIV = ScrambleIV ByteString
-    deriving (Eq,Ord,Show,Typeable,ByteArrayAccess)
+    deriving (Eq,Ord,Show,ByteArrayAccess)
 instance Arbitrary ScrambleIV where
     arbitrary = do
         l <- arbitrary :: Gen (ListN IVSizeBytes Word8)

--- a/src/Cardano/Crypto/Wallet.hs
+++ b/src/Cardano/Crypto/Wallet.hs
@@ -51,7 +51,6 @@ module Cardano.Crypto.Wallet
     , verify
     ) where
 
-import           Basement.Compat.Typeable
 import           Control.DeepSeq                 (NFData)
 import           Control.Arrow                   (second)
 import           Crypto.Error                    (throwCryptoError, CryptoFailable(..), CryptoError(..))
@@ -74,12 +73,12 @@ import           Cardano.Crypto.Wallet.Types
 import           GHC.Stack
 
 newtype XPrv = XPrv EncryptedKey
-    deriving (NFData, Typeable, ByteArrayAccess)
+    deriving (NFData, ByteArrayAccess)
 
 data XPub = XPub
     { xpubPublicKey :: !ByteString
     , xpubChaincode :: !ChainCode
-    } deriving (Eq, Show, Ord, Typeable, Generic)
+    } deriving (Eq, Show, Ord, Generic)
 
 instance NFData XPub
 instance Hashable XPub

--- a/src/Cardano/Crypto/Wallet/Types.hs
+++ b/src/Cardano/Crypto/Wallet/Types.hs
@@ -18,7 +18,7 @@ import Foundation.Check (Arbitrary(..), frequency)
 type DerivationIndex = Word32
 
 data DerivationScheme = DerivationScheme1 | DerivationScheme2
-    deriving (Show, Eq, Ord, Enum, Bounded, Typeable)
+    deriving (Show, Eq, Ord, Enum, Bounded)
 instance Arbitrary DerivationScheme where
     arbitrary = frequency $ nonEmpty_ [ (1, pure DerivationScheme1), (1, pure DerivationScheme2) ]
 

--- a/src/Compat/ByteArray.hs
+++ b/src/Compat/ByteArray.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+-- | 'AsBytes' grants 'ByteArrayAccess' to @basement@\/@foundation@ byte-array
+-- types ('Base.String', 'Base.UArray') without defining orphan instances on
+-- those types directly.
+--
+-- The @ram@ package (a maintained fork of the now-unmaintained @memory@
+-- package, which used to provide these instances behind its @foundation@
+-- cabal flag) does not ship them. We can't define them as ordinary orphan
+-- instances on 'Base.String' \/ 'Base.UArray' because the pinned @inspector@
+-- test dependency already defines the same orphans for its own internal use
+-- (it also converts between Foundation byte-array types and 'ram'-based
+-- 'ByteArrayAccess'). Two packages both defining an orphan instance for the
+-- same type conflict wherever both packages are visible together, as they
+-- are in the golden-test executables, which depend on both this library and
+-- @inspector@. Instances on the local 'AsBytes' wrapper can't collide with
+-- anything defined elsewhere, since nothing outside this package mentions
+-- 'AsBytes'.
+module Compat.ByteArray
+    ( AsBytes (..)
+    ) where
+
+import Data.ByteArray (ByteArrayAccess (..))
+import Data.Word      (Word8)
+import Foreign.Ptr    (castPtr)
+
+import qualified Basement.String           as Base (Encoding (UTF8), String, toBytes)
+import qualified Basement.Types.OffsetSize as Base
+import qualified Basement.UArray           as Base
+
+import Prelude hiding (length)
+
+-- | Wrapper granting 'ByteArrayAccess' to a foundation\/basement byte-array
+-- type without creating an orphan instance on the bare type itself.
+newtype AsBytes a = AsBytes a
+
+baseUarrayRecastW8 :: Base.PrimType ty => Base.UArray ty -> Base.UArray Word8
+baseUarrayRecastW8 = Base.recast
+
+instance Base.PrimType ty => ByteArrayAccess (AsBytes (Base.UArray ty)) where
+    length (AsBytes a) = let Base.CountOf i = Base.length (baseUarrayRecastW8 a) in i
+    withByteArray (AsBytes a) f = Base.withPtr (baseUarrayRecastW8 a) (f . castPtr)
+
+instance ByteArrayAccess (AsBytes Base.String) where
+    length (AsBytes str) = let Base.CountOf i = Base.length bytes in i
+      where
+        -- Foundation's length returns a number of elements, not bytes.
+        bytes = Base.toBytes Base.UTF8 str
+    withByteArray (AsBytes str) f = withByteArray (AsBytes (Base.toBytes Base.UTF8 str)) f

--- a/src/Crypto/Encoding/BIP39.hs
+++ b/src/Crypto/Encoding/BIP39.hs
@@ -96,6 +96,7 @@ import qualified Crypto.KDF.PBKDF2 as PBKDF2
 
 import           Crypto.Encoding.BIP39.Dictionary
 import           Cardano.Internal.Compat (fromRight)
+import           Compat.ByteArray (AsBytes (..))
 
 -- -------------------------------------------------------------------------- --
 -- Entropy
@@ -297,8 +298,8 @@ phraseToSeed :: ValidMnemonicSentence mw
 phraseToSeed mw dic passphrase =
     PBKDF2.fastPBKDF2_SHA512
                     (PBKDF2.Parameters 2048 64)
-                    sentence
-                    (toData ("mnemonic" `mappend` passphrase))
+                    (AsBytes sentence)
+                    (AsBytes (toData ("mnemonic" `mappend` passphrase)))
   where
     sentence = toData $ mnemonicPhraseToString dic mw
     toData = String.toBytes String.UTF8

--- a/src/Crypto/Encoding/BIP39.hs
+++ b/src/Crypto/Encoding/BIP39.hs
@@ -69,7 +69,6 @@ import           Basement.Nat
 import qualified Basement.Sized.List as ListN
 import           Basement.Sized.List (ListN)
 import           Basement.NormalForm
-import           Basement.Compat.Typeable
 import           Basement.Numerical.Number (IsIntegral(..))
 import           Basement.Imports
 
@@ -104,7 +103,7 @@ import           Cardano.Internal.Compat (fromRight)
 --
 -- the 'Nat' type parameter represent the size, in bits, of this checksum.
 newtype Checksum (bits :: Nat) = Checksum Word8
-    deriving (Show, Eq, Typeable, NormalForm)
+    deriving (Show, Eq, NormalForm)
 
 checksum :: forall csz ba . (KnownNat csz, ByteArrayAccess ba)
          => ba -> Checksum csz
@@ -137,7 +136,7 @@ data Entropy (n :: Nat) = Entropy
      , entropyChecksum :: !(Checksum (CheckSumBits n))
         -- ^ Get the checksum of the Entropy
      }
-  deriving (Show, Eq, Typeable)
+  deriving (Show, Eq)
 instance NormalForm (Entropy n) where
     toNormalForm (Entropy !_ cs) = toNormalForm cs
 instance Arbitrary (Entropy 96) where
@@ -272,7 +271,7 @@ entropyToWords (Entropy bs (Checksum w)) =
 -- -------------------------------------------------------------------------- --
 
 newtype Seed = Seed ByteString
-  deriving (Show, Eq, Ord, Typeable, Semigroup, Monoid, ByteArrayAccess, ByteArray, IsString)
+  deriving (Show, Eq, Ord, Semigroup, Monoid, ByteArrayAccess, ByteArray, IsString)
 
 type Passphrase = String
 
@@ -317,7 +316,7 @@ phraseToSeed mw dic passphrase =
 newtype MnemonicSentence (mw :: Nat) = MnemonicSentence
     { mnemonicSentenceToListN :: ListN mw WordIndex
     }
-  deriving (Show, Eq, Ord, Typeable, NormalForm)
+  deriving (Show, Eq, Ord, NormalForm)
 instance ValidMnemonicSentence mw => IsList (MnemonicSentence mw) where
     type Item (MnemonicSentence mw) = WordIndex
     fromList = MnemonicSentence . fromMaybe (error "invalid mnemonic size") . ListN.toListN
@@ -336,7 +335,7 @@ type ValidMnemonicSentence (mw :: Nat) =
 newtype MnemonicPhrase (mw :: Nat) = MnemonicPhrase
     { mnemonicPhraseToListN :: ListN mw String
     }
-  deriving (Show, Eq, Ord, Typeable, NormalForm)
+  deriving (Show, Eq, Ord, NormalForm)
 instance ValidMnemonicSentence mw => IsList (MnemonicPhrase mw) where
     type Item (MnemonicPhrase mw) = String
     fromList = fromRight (error "invalid mnemonic phrase") . mnemonicPhrase

--- a/src/Crypto/Encoding/BIP39.hs
+++ b/src/Crypto/Encoding/BIP39.hs
@@ -88,6 +88,8 @@ import           Data.Proxy
 
 import           GHC.TypeLits
 
+import           Prelude (type (~))
+
 import           Crypto.Hash (hashWith, SHA256(..))
 import           Crypto.Number.Serialize (os2ip, i2ospOf_)
 import qualified Crypto.KDF.PBKDF2 as PBKDF2

--- a/src/Crypto/Encoding/BIP39/Dictionary.hs
+++ b/src/Crypto/Encoding/BIP39/Dictionary.hs
@@ -22,7 +22,6 @@ module Crypto.Encoding.BIP39.Dictionary
     ) where
 
 import           Basement.NormalForm
-import           Basement.Compat.Typeable
 import           Basement.Types.OffsetSize (Offset(..))
 import           Basement.From (TryFrom(..))
 import           Basement.Imports
@@ -44,14 +43,13 @@ data Dictionary = Dictionary
     , dictionaryWordSeparator :: String
       -- ^ joining string (e.g. space for english)
     }
-  deriving (Typeable)
 
 -- | Index of the mnemonic word in the 'Dictionary'
 --
 -- 'WordIndex' are within range of [0..2047]
 --
 newtype WordIndex = WordIndex { unWordIndex :: Offset String }
-    deriving (Show, Eq, Ord, Typeable, NormalForm)
+    deriving (Show, Eq, Ord, NormalForm)
 instance Enum WordIndex where
     toEnum = wordIndex . toEnum
     fromEnum = fromEnum . unWordIndex

--- a/src/Crypto/Math/Edwards25519.hs
+++ b/src/Crypto/Math/Edwards25519.hs
@@ -51,11 +51,8 @@ import           Crypto.Hash
 import           Crypto.Number.ModArithmetic
 import           Crypto.Number.Serialize
 import           Data.Bits
-#if MIN_VERSION_memory(0,14,18)
-import qualified Data.ByteArray              as B hiding (append, reverse)
-#else
-import qualified Data.ByteArray              as B hiding (append)
-#endif
+
+import qualified Data.ByteArray              as BA hiding (append)
 import           Data.ByteString             (ByteString)
 import qualified Data.ByteString             as B (append, reverse)
 import           Data.Hashable               (Hashable)
@@ -94,11 +91,11 @@ fq = Fq
 -- to be in the right base field range on purpose.
 scalar :: ByteString -> Scalar
 scalar bs
-    | B.length bs /= 32 = error "invalid scalar"
+    | BA.length bs /= 32 = error "invalid scalar"
     | otherwise         = Scalar bs
 
 scalarP :: Bytes 32 -> Scalar
-scalarP = scalar . B.pack . Bytes.unpack
+scalarP = scalar . BA.pack . Bytes.unpack
 
 
 -- | Check if a scalar is valid and all the bits properly set/cleared
@@ -110,44 +107,44 @@ scalarP = scalar . B.pack . Bytes.unpack
 -- Check if the length is of expected size
 pointCompressed :: HasCallStack => ByteString -> PointCompressed
 pointCompressed bs
-    | B.length bs /= 32 = error ("invalid compressed point: expecting 32 bytes, got " ++ show (B.length bs) ++ " bytes")
+    | BA.length bs /= 32 = error ("invalid compressed point: expecting 32 bytes, got " ++ show (BA.length bs) ++ " bytes")
     | otherwise         = PointCompressed bs
 
 pointCompressedP :: Bytes 32 -> PointCompressed
-pointCompressedP = pointCompressed . B.pack . Bytes.unpack
+pointCompressedP = pointCompressed . BA.pack . Bytes.unpack
 
 unPointCompressedP :: PointCompressed -> Bytes 32
-unPointCompressedP (PointCompressed bs) = Bytes.pack $ B.unpack bs
+unPointCompressedP (PointCompressed bs) = Bytes.pack $ BA.unpack bs
 
 -- | Create a signature using a variant of ED25519 signature
 --
 -- we don't hash the secret key to derive a key + prefix, but
 -- instead we take an explicit salt and compute a prefix
 -- using the secret key + salt.
-sign :: B.ByteArrayAccess msg => Scalar -> ByteString -> msg -> Signature
+sign :: BA.ByteArrayAccess msg => Scalar -> ByteString -> msg -> Signature
 sign a salt msg =
     Signature (unPointCompressed pR `B.append` toBytes s)
   where
     prefix = hash ((unScalar a) `B.append` salt) :: Digest SHA512
     pA = scalarToPoint a
-    r = sha512_modq (B.convert prefix `B.append` B.convert msg)
+    r = sha512_modq (BA.convert prefix `B.append` BA.convert msg)
     pR = ePointCompress $ ePointMul r pG
-    h = sha512_modq (unPointCompressed pR `B.append` unPointCompressed pA `B.append` B.convert msg)
+    h = sha512_modq (unPointCompressed pR `B.append` unPointCompressed pA `B.append` BA.convert msg)
     s = (unFq r + unFq h * (fromBytes (unScalar a))) `mod` q
 
 -- | Verify a signature
-verify :: B.ByteArrayAccess msg => PointCompressed -> msg -> Signature -> Bool
+verify :: BA.ByteArrayAccess msg => PointCompressed -> msg -> Signature -> Bool
 verify pA msg (Signature signature) =
     pS `pointEqual` ePointAdd (ePointDecompress pR) hA
   where
     (pR, s) =
-        let (sig0, sig1) = B.splitAt 32 signature
+        let (sig0, sig1) = BA.splitAt 32 signature
          in (PointCompressed sig0, fq $ fromBytes sig1)
 
     pointEqual (ExtendedPoint pX pY pZ _) (ExtendedPoint qX qY qZ _) =
         ((pX * qZ - qX * pZ) `mod` p == 0) && ((pY * qZ - qY * pZ) `mod` p == 0)
 
-    h = sha512_modq (unPointCompressed pR `B.append` unPointCompressed pA `B.append` B.convert msg)
+    h = sha512_modq (unPointCompressed pR `B.append` unPointCompressed pA `B.append` BA.convert msg)
     pS = ePointMul s pG
     hA = ePointMul h (ePointDecompress pA)
 
@@ -263,6 +260,6 @@ pG = ExtendedPoint g_x g_y 1 ((g_x * g_y) `mod` p)
     !g_y = (4 * modp_inv 5) `mod` p
     !g_x = recoverX g_y False
 
-sha512_modq :: B.ByteArrayAccess ba => ba -> Fq
+sha512_modq :: BA.ByteArrayAccess ba => ba -> Fq
 sha512_modq bs =
-    Fq (fromBytes (B.convert (hash bs :: Digest SHA512)) `mod` q)
+    Fq (fromBytes (BA.convert (hash bs :: Digest SHA512)) `mod` q)

--- a/test/GoldenTest.hs
+++ b/test/GoldenTest.hs
@@ -183,7 +183,7 @@ goldenSignatureEd25519 = golden (Proxy :: Proxy SignatureEd25519) verify
 
 -- | `m/0'/1'/1000'`
 newtype ChainCodePath = Root [Word32]
-  deriving (Show, Eq, Typeable)
+  deriving (Show, Eq)
 instance Arbitrary ChainCodePath where
     arbitrary = Root <$> arbitrary
 
@@ -199,7 +199,7 @@ data Language = English
 -- | a convenient type to help read/parse/document expected input of type
 -- BIP39 mnemonics
 newtype Mnemonic (k :: Language) n = Mnemonic (MnemonicSentence n)
-  deriving (Eq, Typeable)
+  deriving (Eq)
 
 -- | The type of master key generation
 data MasterKeyGeneration = MasterKeyRetryOld | MasterKeyPBKDF


### PR DESCRIPTION
Biggest part of this PR is switching from an unmaintained `memory` package to a maintained `ram` package. The latter is supposed to be a drop in replacement but is lacking some typeclass instances that the former used to provide. The missing instances have been added in a new `Compat.ByteArray` module and orphan instances were avoided by using a newtype wrapper.

Other changes in the PR should be obvious and self-explanatory.

Due to the change in the dependencies, the version number of this package has been bumped from `1.3.0` to `1.4.0`.