### PR TITLE
Rename Compat.ByteArray to Cardano.Crypto.Compat

### DIFF
--- a/cardano-crypto.cabal
+++ b/cardano-crypto.cabal
@@ -43,7 +43,7 @@ library
                        Crypto.Encoding.BIP39.Dictionary
                        Crypto.Encoding.BIP39.English
                        Cardano.Internal.Compat
-  other-modules:       Compat.ByteArray
+  other-modules:       Cardano.Crypto.Compat
   build-depends:       base >= 4.7 && < 5
                      , array
                      , basement >= 0.0.16

--- a/src/Cardano/Crypto/Compat.hs
+++ b/src/Cardano/Crypto/Compat.hs
@@ -17,7 +17,7 @@
 -- @inspector@. Instances on the local 'AsBytes' wrapper can't collide with
 -- anything defined elsewhere, since nothing outside this package mentions
 -- 'AsBytes'.
-module Compat.ByteArray
+module Cardano.Crypto.Compat
     ( AsBytes (..)
     ) where
 

--- a/src/Cardano/Crypto/Encoding/Seed.hs
+++ b/src/Cardano/Crypto/Encoding/Seed.hs
@@ -52,7 +52,7 @@ import Basement.Nat
 import Crypto.Error
 
 import Data.ByteArray (xor, ScrubbedBytes)
-import Compat.ByteArray (AsBytes (..))
+import Cardano.Crypto.Compat (AsBytes (..))
 import Crypto.Encoding.BIP39
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import           Basement.Sized.List (ListN)

--- a/src/Crypto/Encoding/BIP39.hs
+++ b/src/Crypto/Encoding/BIP39.hs
@@ -96,7 +96,7 @@ import qualified Crypto.KDF.PBKDF2 as PBKDF2
 
 import           Crypto.Encoding.BIP39.Dictionary
 import           Cardano.Internal.Compat (fromRight)
-import           Compat.ByteArray (AsBytes (..))
+import           Cardano.Crypto.Compat (AsBytes (..))
 
 -- -------------------------------------------------------------------------- --
 -- Entropy


### PR DESCRIPTION
Renaming a hidden module so no version bump needed.